### PR TITLE
Remove samba variables

### DIFF
--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,2 +1,0 @@
----
-samba_daemon: smbd

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,2 +1,0 @@
----
-samba_daemon: smb


### PR DESCRIPTION
Ha, I've written an almost identical role!

As far as I can see with this, the samba variables aren't used anywhere, so can be removed?