### PR TITLE
Manage config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Generally, installing from source (see section `Source Installation from Git`) l
 
 The variable `certbot_install_from_source` controls whether to install Certbot from Git or package management. The latter is the default, so the variable defaults to `no`.
 
+The variable `certbot_config_file_options` defaults to an empty dictionary but can be used to configure global options for Certbot, which will go into `/etc/letsencrypt/cli.ini`.
+
     certbot_auto_renew: true
     certbot_auto_renew_user: "{{ ansible_user }}"
     certbot_auto_renew_hour: 3
@@ -82,12 +84,14 @@ None.
 ## Example Playbook
 
     - hosts: servers
-    
+
       vars:
+        certbot_config_file_options:
+          rsa-key-size: 4096
         certbot_auto_renew_user: your_username_here
         certbot_auto_renew_minute: 20
         certbot_auto_renew_hour: 5
-    
+
       roles:
         - geerlingguy.certbot
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,7 @@
 ---
+# Global options for configuration file
+certbot_config_file_options: {}
+
 # Certbot auto-renew cron job configuration (for certificate renewals).
 certbot_auto_renew: true
 certbot_auto_renew_user: "{{ ansible_user }}"

--- a/tasks/config-file.yml
+++ b/tasks/config-file.yml
@@ -1,0 +1,10 @@
+---
+- name: Ensure configuration directory is present.
+  file:
+    path: /etc/letsencrypt
+    state: directory
+
+- name: Install Certbot configuration file.
+  template:
+    src: cli.ini.j2
+    dest: /etc/letsencrypt/cli.ini

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,6 +7,8 @@
 - import_tasks: install-from-source.yml
   when: certbot_install_from_source
 
+- import_tasks: config-file.yml
+
 - include_tasks: create-cert-standalone.yml
   with_items: "{{ certbot_certs }}"
   when:

--- a/templates/cli.ini.j2
+++ b/templates/cli.ini.j2
@@ -1,0 +1,5 @@
+# {{ ansible_managed }}
+
+{% for key, value in certbot_config_file_options.items() %}
+{{ key }} = {{ value }}
+{% endfor %}


### PR DESCRIPTION
Since it was really easy to implement, I fixed #23 w/o waiting for your feedback. Feel free to decline or request changes ;-)

This introduces a role variable that allows to set global options for certbot that go into `/etc/letsencrypt/cli.ini`.