### PR TITLE
Allow cron renew arguments to be configurable

### DIFF
--- a/tasks/renew-cron.yml
+++ b/tasks/renew-cron.yml
@@ -2,7 +2,7 @@
 - name: Add cron job for certbot renewal (if configured).
   cron:
     name: Certbot automatic renewal.
-    job: "{{ certbot_script }} renew --quiet --no-self-upgrade"
+    job: "{{ certbot_script }} renew {{ certbot_auto_renew_args }}"
     minute: "{{ certbot_auto_renew_minute }}"
     hour: "{{ certbot_auto_renew_hour }}"
     user: "{{ certbot_auto_renew_user }}"

--- a/vars/Ubuntu-16.04.yml
+++ b/vars/Ubuntu-16.04.yml
@@ -1,1 +1,2 @@
 certbot_package: letsencrypt
+certbot_auto_renew_args: "--no-self-upgrade"

--- a/vars/default.yml
+++ b/vars/default.yml
@@ -1,2 +1,3 @@
 ---
 certbot_package: certbot
+certbot_auto_renew_args: "--quiet --no-self-upgrade"


### PR DESCRIPTION
The current version of the Let's Encrypt package does not allow the "--quiet parameter on Ubuntu 16.04:

```sh
root@server:~# letsencrypt renew --quiet --no-self-upgrade
usage: 
  letsencrypt [SUBCOMMAND] [options] [-d domain] [-d domain] ...

The Let's Encrypt agent can obtain and install HTTPS/TLS/SSL certificates.  By
default, it will attempt to use a webserver both for obtaining and installing
the cert. Major SUBCOMMANDS are:

  (default) run        Obtain & install a cert in your current webserver
  certonly             Obtain cert, but do not install it (aka "auth")
  install              Install a previously obtained cert in a server
  renew                Renew previously obtained certs that are near expiry
  revoke               Revoke a previously obtained certificate
  rollback             Rollback server configuration changes made during install
  config_changes       Show changes made to server config during installation
  plugins              Display information about installed plugins
letsencrypt: error: unrecognized arguments: --quiet
```

This PR allows the arguments for the renew command in the cron definition
to be configurable, keeping backward compatibility.
The default behaviour for Ubuntu 16.04 has the "--quiet" parameter removed.