### PR TITLE
Removes --quiet parameter for the ubuntu 16.04 version of letsencrypt

### DIFF
--- a/tasks/renew-cron.yml
+++ b/tasks/renew-cron.yml
@@ -2,7 +2,7 @@
 - name: Add cron job for certbot renewal (if configured).
   cron:
     name: Certbot automatic renewal.
-    job: "{{ certbot_script }} renew --quiet --no-self-upgrade"
+    job: "{{ certbot_script }} {{certbot_renew_command}}"
     minute: "{{ certbot_auto_renew_minute }}"
     hour: "{{ certbot_auto_renew_hour }}"
     user: "{{ certbot_auto_renew_user }}"

--- a/vars/Ubuntu-16.04.yml
+++ b/vars/Ubuntu-16.04.yml
@@ -1,1 +1,2 @@
 certbot_package: letsencrypt
+certbot_renew_command: "renew --no-self-upgrade"

--- a/vars/default.yml
+++ b/vars/default.yml
@@ -1,2 +1,3 @@
 ---
 certbot_package: certbot
+certbot_renew_command: "renew --quiet --no-self-upgrade"


### PR DESCRIPTION
On our Ubuntu 16.04 hosts using the installed package version, the cronjob fails because letsencrypt doesn't support the --quiet parameter.
I remove it using a new var in the included var files. Maybe certbot_script and certbot_renew_command should be combined ?