### PR TITLE
Don't try to restart a service, when no service is defined.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,7 +19,7 @@ certbot_certs: []
   #     - example3.com
 certbot_create_command: "{{ certbot_script }} certonly --standalone --noninteractive --agree-tos --email {{ cert_item.email | default(certbot_admin_email) }} -d {{ cert_item.domains | join(',') }}"
 certbot_create_standalone_stop_services:
-  - nginx
+  # - nginx
   # - apache
   # - varnish
 

--- a/tasks/create-cert-standalone.yml
+++ b/tasks/create-cert-standalone.yml
@@ -8,7 +8,7 @@
   service:
     name: "{{ item }}"
     state: stopped
-  when: not letsencrypt_cert.stat.exists
+  when: not letsencrypt_cert.stat.exists and item != None
   with_items: "{{ certbot_create_standalone_stop_services }}"
 
 - name: Generate new certificate if one doesn't exist.
@@ -19,5 +19,5 @@
   service:
     name: "{{ item }}"
     state: started
-  when: not letsencrypt_cert.stat.exists
+  when: not letsencrypt_cert.stat.exists and item != None
   with_items: "{{ certbot_create_standalone_stop_services }}"


### PR DESCRIPTION
I fixed a bug. In my case I use certbot without a webserver, so there is no service that needs to be stopped before the certificate is generated.