### PR TITLE
#49 Handle domain list change for a certificate

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,7 +17,7 @@ certbot_certs: []
   #     - example2.com
   # - domains:
   #     - example3.com
-certbot_create_command: "{{ certbot_script }} certonly --standalone --noninteractive --agree-tos --email {{ cert_item.email | default(certbot_admin_email) }} -d {{ cert_item.domains | join(',') }}"
+certbot_create_command: "{{ certbot_script }} certonly --standalone --noninteractive --expand --agree-tos --email {{ cert_item.email | default(certbot_admin_email) }} -d {{ cert_item.domains | join(',') }}"
 certbot_create_standalone_stop_services:
   - nginx
   # - apache

--- a/tasks/create-cert-standalone.yml
+++ b/tasks/create-cert-standalone.yml
@@ -1,5 +1,5 @@
 ---
-- name: Check if certificate exists or has been changed
+- name: Check if certificate exists or has been changed.
   import_tasks: test-cert-exists.yml
 
 - name: Stop services to allow certbot to generate a cert.
@@ -13,14 +13,12 @@
   shell: "{{ certbot_create_command }}"
   when: not letsencrypt_cert_exists.stat.exists or letsencrypt_cert_updated
 
-# TODO May use a more direct https://docs.ansible.com/ansible/latest/copy_module.html
-- name: Persist domain list to host
-  lineinfile:
-    path: /etc/letsencrypt/domains-{{ cert_item.domains | first }}
-    line: "{{ cert_item.domains }}"
-    state: present
-    create: yes
-  when: letsencrypt_cert_updated
+- name: Persist domain list to /etc/letsencrypt/domains-{{ cert_item.domains | first }}.
+  copy:
+    dest: /etc/letsencrypt/domains-{{ cert_item.domains | first }}
+    # Add a space here because of https://github.com/ansible/ansible/issues/6077
+    content: " {{ cert_item.domains }}\n"
+  # when: not letsencrypt_cert_exists.stat.exists or letsencrypt_cert_updated
 
 - name: Start services after cert has been generated.
   service:

--- a/tasks/create-cert-standalone.yml
+++ b/tasks/create-cert-standalone.yml
@@ -14,10 +14,11 @@
   when: not letsencrypt_cert_exists.stat.exists
 
 - name: Persist domain list to host
-  copy:
-    content: "{{ cert_item.domains }}"
-    dest: /etc/letsencrypt/domains-{{ cert_item.domains | first }}
-  when: letsencrypt_cert_updated.rc != 0
+  lineinfile:
+    path: /etc/letsencrypt/domains-{{ cert_item.domains | first }}
+    line: "{{ cert_item.domains }}"
+    state: present
+  when: letsencrypt_cert_updated
 
 - name: Start services after cert has been generated.
   service:

--- a/tasks/create-cert-standalone.yml
+++ b/tasks/create-cert-standalone.yml
@@ -1,23 +1,27 @@
 ---
-- name: Check if certificate already exists.
-  stat:
-    path: /etc/letsencrypt/live/{{ cert_item.domains | first }}/cert.pem
-  register: letsencrypt_cert
+- name: Check if certificate exists or has been changed
+  import_tasks: test-cert-exists.yml
 
 - name: Stop services to allow certbot to generate a cert.
   service:
     name: "{{ item }}"
     state: stopped
-  when: not letsencrypt_cert.stat.exists
+  when: not letsencrypt_cert_exists.stat.exists
   with_items: "{{ certbot_create_standalone_stop_services }}"
 
 - name: Generate new certificate if one doesn't exist.
   shell: "{{ certbot_create_command }}"
-  when: not letsencrypt_cert.stat.exists
+  when: not letsencrypt_cert_exists.stat.exists
+
+- name: Persist domain list to host
+  copy:
+    content: "{{ cert_item.domains }}"
+    dest: /etc/letsencrypt/domains-{{ cert_item.domains | first }}
+  when: letsencrypt_cert_updated.rc != 0
 
 - name: Start services after cert has been generated.
   service:
     name: "{{ item }}"
     state: started
-  when: not letsencrypt_cert.stat.exists
+  when: not letsencrypt_cert_exists.stat.exists
   with_items: "{{ certbot_create_standalone_stop_services }}"

--- a/tasks/create-cert-standalone.yml
+++ b/tasks/create-cert-standalone.yml
@@ -6,23 +6,24 @@
   service:
     name: "{{ item }}"
     state: stopped
-  when: not letsencrypt_cert_exists.stat.exists
+  when: not letsencrypt_cert_exists.stat.exists or letsencrypt_cert_updated
   with_items: "{{ certbot_create_standalone_stop_services }}"
 
 - name: Generate new certificate if one doesn't exist.
   shell: "{{ certbot_create_command }}"
-  when: not letsencrypt_cert_exists.stat.exists
+  when: not letsencrypt_cert_exists.stat.exists or letsencrypt_cert_updated
 
 - name: Persist domain list to host
   lineinfile:
     path: /etc/letsencrypt/domains-{{ cert_item.domains | first }}
     line: "{{ cert_item.domains }}"
     state: present
+    create: yes
   when: letsencrypt_cert_updated
 
 - name: Start services after cert has been generated.
   service:
     name: "{{ item }}"
     state: started
-  when: not letsencrypt_cert_exists.stat.exists
+  when: not letsencrypt_cert_exists.stat.exists or letsencrypt_cert_updated
   with_items: "{{ certbot_create_standalone_stop_services }}"

--- a/tasks/create-cert-standalone.yml
+++ b/tasks/create-cert-standalone.yml
@@ -13,6 +13,7 @@
   shell: "{{ certbot_create_command }}"
   when: not letsencrypt_cert_exists.stat.exists or letsencrypt_cert_updated
 
+# TODO May use a more direct https://docs.ansible.com/ansible/latest/copy_module.html
 - name: Persist domain list to host
   lineinfile:
     path: /etc/letsencrypt/domains-{{ cert_item.domains | first }}

--- a/tasks/create-cert-standalone.yml
+++ b/tasks/create-cert-standalone.yml
@@ -15,10 +15,10 @@
 
 - name: Persist domain list to /etc/letsencrypt/domains-{{ cert_item.domains | first }}.
   copy:
-    dest: /etc/letsencrypt/domains-{{ cert_item.domains | first }}
+    dest: /etc/letsencrypt/domains-{{ cert_item.domains | first }}.json
     # Add a space here because of https://github.com/ansible/ansible/issues/6077
-    content: " {{ cert_item.domains }}\n"
-  # when: not letsencrypt_cert_exists.stat.exists or letsencrypt_cert_updated
+    content: " {{ cert_item.domains | to_json }}\n"
+  when: not letsencrypt_cert_exists.stat.exists or letsencrypt_cert_updated
 
 - name: Start services after cert has been generated.
   service:

--- a/tasks/test-cert-exists.yml
+++ b/tasks/test-cert-exists.yml
@@ -1,0 +1,21 @@
+---
+- name: Check if certificate already exists.
+  stat:
+    path: /etc/letsencrypt/live/{{ cert_item.domains | first }}/cert.pem
+  register: letsencrypt_cert_exists
+
+- name: Check if certificate has changed.
+  command: grep -Fxq "{{ cert_item.domains }}" /etc/letsencrypt/domains-{{ cert_item.domains | first }}
+  register: letsencrypt_cert_updated
+  check_mode: no
+  ignore_errors: yes
+  changed_when: no
+  when: letsencrypt_cert_exists.stat.exists
+
+- debug:
+    msg: Not changed
+  when: letsencrypt_cert_updated.rc == 0
+
+- debug:
+    msg: Changed
+  when: letsencrypt_cert_updated.rc != 0

--- a/tasks/test-cert-exists.yml
+++ b/tasks/test-cert-exists.yml
@@ -5,17 +5,14 @@
   register: letsencrypt_cert_exists
 
 - name: Check if certificate has changed.
-  command: grep -Fxq "{{ cert_item.domains }}" /etc/letsencrypt/domains-{{ cert_item.domains | first }}
-  register: letsencrypt_cert_updated
-  check_mode: no
-  ignore_errors: yes
-  changed_when: no
+  lineinfile:
+    path: /etc/letsencrypt/domains-{{ cert_item.domains | first }}
+    line: "{{ cert_item.domains }}"
+    state: present
+  check_mode: yes
+  register: letsencrypt_cert_contents
   when: letsencrypt_cert_exists.stat.exists
 
-- debug:
-    msg: Not changed
-  when: letsencrypt_cert_updated.rc == 0
-
-- debug:
-    msg: Changed
-  when: letsencrypt_cert_updated.rc != 0
+- set_fact:
+    letsencrypt_cert_updated: "{{ (letsencrypt_cert_contents | changed) or (letsencrypt_cert_contents | failed) }}"
+  when: letsencrypt_cert_exists.stat.exists

--- a/tasks/test-cert-exists.yml
+++ b/tasks/test-cert-exists.yml
@@ -6,8 +6,8 @@
 
 - name: Check if certificate domain list has changed.
   lineinfile:
-    path: /etc/letsencrypt/domains-{{ cert_item.domains | first }}
-    line: " {{ cert_item.domains }}"
+    path: /etc/letsencrypt/domains-{{ cert_item.domains | first }}.json
+    line: " {{ cert_item.domains | to_json }}"
     state: present
     create: yes
   check_mode: yes

--- a/tasks/test-cert-exists.yml
+++ b/tasks/test-cert-exists.yml
@@ -4,15 +4,21 @@
     path: /etc/letsencrypt/live/{{ cert_item.domains | first }}/cert.pem
   register: letsencrypt_cert_exists
 
-- name: Check if certificate has changed.
+- name: Check if certificate domain list exists.
+  stat:
+    path: /etc/letsencrypt/domains-{{ cert_item.domains | first }}
+  register: letsencrypt_cert_list_exists
+  when: letsencrypt_cert_exists.stat.exists
+
+- name: Check if certificate domain list has changed.
   lineinfile:
     path: /etc/letsencrypt/domains-{{ cert_item.domains | first }}
     line: "{{ cert_item.domains }}"
     state: present
   check_mode: yes
   register: letsencrypt_cert_contents
-  when: letsencrypt_cert_exists.stat.exists
+  when: letsencrypt_cert_exists.stat.exists and letsencrypt_cert_list_exists.stat.exists
 
 - set_fact:
-    letsencrypt_cert_updated: "{{ (letsencrypt_cert_contents | changed) or (letsencrypt_cert_contents | failed) }}"
+    letsencrypt_cert_updated: "{{ not letsencrypt_cert_list_exists.stat.exists or (letsencrypt_cert_contents | changed) or (letsencrypt_cert_contents | failed) }}"
   when: letsencrypt_cert_exists.stat.exists

--- a/tasks/test-cert-exists.yml
+++ b/tasks/test-cert-exists.yml
@@ -7,7 +7,7 @@
 - name: Check if certificate domain list has changed.
   lineinfile:
     path: /etc/letsencrypt/domains-{{ cert_item.domains | first }}
-    line: "{{ cert_item.domains }}"
+    line: " {{ cert_item.domains }}"
     state: present
     create: yes
   check_mode: yes

--- a/tasks/test-cert-exists.yml
+++ b/tasks/test-cert-exists.yml
@@ -4,21 +4,16 @@
     path: /etc/letsencrypt/live/{{ cert_item.domains | first }}/cert.pem
   register: letsencrypt_cert_exists
 
-- name: Check if certificate domain list exists.
-  stat:
-    path: /etc/letsencrypt/domains-{{ cert_item.domains | first }}
-  register: letsencrypt_cert_list_exists
-  when: letsencrypt_cert_exists.stat.exists
-
 - name: Check if certificate domain list has changed.
   lineinfile:
     path: /etc/letsencrypt/domains-{{ cert_item.domains | first }}
     line: "{{ cert_item.domains }}"
     state: present
+    create: yes
   check_mode: yes
   register: letsencrypt_cert_contents
-  when: letsencrypt_cert_exists.stat.exists and letsencrypt_cert_list_exists.stat.exists
+  when: letsencrypt_cert_exists.stat.exists
 
 - set_fact:
-    letsencrypt_cert_updated: "{{ not letsencrypt_cert_list_exists.stat.exists or (letsencrypt_cert_contents | changed) or (letsencrypt_cert_contents | failed) }}"
+    letsencrypt_cert_updated: "{{ (letsencrypt_cert_contents | changed) or (letsencrypt_cert_contents | failed) }}"
   when: letsencrypt_cert_exists.stat.exists


### PR DESCRIPTION
For solving #49, we persist to the host machine a file containing the list of domains for a given certificate.

If this list does not match the one provided in the current configuration, the certificate is issued again.

Beware: this make certificate expansion (`--expand`) the default implicit behavior. Maybe we could make it an option and only try to update the certificate if the variable `certbot_auto_expand` is set to true.

Anyway, it now works as I would expect when using `certbot_auto_renew`: if we added a domain to one of our certificates, it is updated so the domain is now covered.