### PR TITLE
Add become method to the required tasks

### DIFF
--- a/tasks/create-cert-standalone.yml
+++ b/tasks/create-cert-standalone.yml
@@ -1,5 +1,6 @@
 ---
 - name: Check if certificate already exists.
+  become: True
   stat:
     path: /etc/letsencrypt/live/{{ cert_item.domains | first }}/cert.pem
   register: letsencrypt_cert
@@ -22,7 +23,5 @@
   service:
     name: "{{ item }}"
     state: started
-  when:
-    - not letsencrypt_cert.stat.exists
-    - certbot_create_standalone_stop_services
+  when: not letsencrypt_cert.stat.exists
   with_items: "{{ certbot_create_standalone_stop_services }}"

--- a/tasks/create-cert-standalone.yml
+++ b/tasks/create-cert-standalone.yml
@@ -22,5 +22,7 @@
   service:
     name: "{{ item }}"
     state: started
-  when: not letsencrypt_cert.stat.exists
+  when:
+    - not letsencrypt_cert.stat.exists
+    - certbot_create_standalone_stop_services
   with_items: "{{ certbot_create_standalone_stop_services }}"

--- a/tasks/create-cert-standalone.yml
+++ b/tasks/create-cert-standalone.yml
@@ -5,6 +5,7 @@
   register: letsencrypt_cert
 
 - name: Stop services to allow certbot to generate a cert.
+  become: True
   service:
     name: "{{ item }}"
     state: stopped
@@ -12,10 +13,12 @@
   with_items: "{{ certbot_create_standalone_stop_services }}"
 
 - name: Generate new certificate if one doesn't exist.
+  become: True
   shell: "{{ certbot_create_command }}"
   when: not letsencrypt_cert.stat.exists
 
 - name: Start services after cert has been generated.
+  become: True
   service:
     name: "{{ item }}"
     state: started

--- a/tasks/install-from-source.yml
+++ b/tasks/install-from-source.yml
@@ -12,6 +12,7 @@
     certbot_script: "{{ certbot_dir }}/certbot-auto"
 
 - name: Ensure certbot-auto is executable.
+  become: True
   file:
     path: "{{ certbot_script }}"
     mode: 0755

--- a/tasks/install-with-package.yml
+++ b/tasks/install-with-package.yml
@@ -1,5 +1,6 @@
 ---
 - name: Install Certbot.
+  become: True
   package: "name={{ certbot_package }} state=present"
 
 - name: Set Certbot script variable.

--- a/tasks/renew-cron.yml
+++ b/tasks/renew-cron.yml
@@ -1,5 +1,6 @@
 ---
 - name: Add cron job for certbot renewal (if configured).
+  become: True
   cron:
     name: Certbot automatic renewal.
     job: "{{ certbot_script }} renew {{ certbot_auto_renew_options }}"


### PR DESCRIPTION
I added the `become: True` to the required tasks, so that it's not needed to run the role with root