### PR TITLE
allow installation using pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Installs and configures Certbot (for Let's Encrypt).
 ## Requirements
 
 If installing from source, Git is required. You can install Git using the `geerlingguy.git` role.
+If installing from pip, pip is required.
 
 Generally, installing from source (see section `Source Installation from Git`) leads to a better experience using Certbot and Let's Encrypt, especially if you're using an older OS release.
 
@@ -60,11 +61,18 @@ Services that should be stopped while `certbot` runs it's own standalone server 
 
 These services will only be stopped the first time a new cert is generated.
 
+### Installation from pip (or pip3)
+
+    certbot_install: 'pip'
+    # or certbot_install: 'pip3'
+
+The resulting certbot program will live in /usr/local/bin/certbot
+
 ### Source Installation from Git
 
 You can install Certbot from it's Git source repository if desired. This might be useful in several cases, but especially when older distributions don't have Certbot packages available (e.g. CentOS < 7, Ubuntu < 16.10 and Debian < 8).
 
-    certbot_install_from_source: false
+    certbot_install: "source"
     certbot_repo: https://github.com/certbot/certbot.git
     certbot_version: master
     certbot_keep_updated: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,9 +27,14 @@ certbot_create_standalone_stop_services:
   # - apache
   # - varnish
 
-# To install from source (on older OSes or if you need a specific or newer
-# version of Certbot), set this variable to `yes` and configure other options.
-certbot_install_from_source: false
+# Possible choices include:
+# - "source" (on older OSes or if you need a specific or newer version of Certbot)
+# - "pkg" (for distribution package)
+# - "pip" (or "pip3")
+# - False (to omit installation)
+certbot_install: "pkg"
+
+# Next 4 options only apply to certbot_install: "source"
 certbot_repo: https://github.com/certbot/certbot.git
 certbot_version: master
 certbot_keep_updated: true

--- a/molecule/default/playbook-source-install.yml
+++ b/molecule/default/playbook-source-install.yml
@@ -4,7 +4,7 @@
   become: true
 
   vars:
-    certbot_install_from_source: true
+    certbot_install: "source"
     certbot_auto_renew_user: root
 
   pre_tasks:

--- a/tasks/install-with-pip.yml
+++ b/tasks/install-with-pip.yml
@@ -1,12 +1,4 @@
 ---
-- name: Install pip
-  package: name=python-pip state=present
-  when: certbot_install == 'pip'
-
-- name: Install pip3
-  package: name=python3-pip state=present
-  when: certbot_install == 'pip3'
-
 - name: Install Certbot.
   pip: name="{{ certbot_package }}" state=present executable="{{ certbot_install }}"
 

--- a/tasks/install-with-pip.yml
+++ b/tasks/install-with-pip.yml
@@ -1,0 +1,15 @@
+---
+- name: Install pip
+  package: name=python-pip state=present
+  when: certbot_install == 'pip'
+
+- name: Install pip3
+  package: name=python3-pip state=present
+  when: certbot_install == 'pip3'
+
+- name: Install Certbot.
+  pip: name="{{ certbot_package }}" state=present executable="{{ certbot_install }}"
+
+- name: Set Certbot script variable.
+  set_fact:
+    certbot_script: /usr/local/bin/certbot

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,10 +2,13 @@
 - import_tasks: include-vars.yml
 
 - import_tasks: install-with-package.yml
-  when: not certbot_install_from_source
+  when: certbot_install == 'pkg' and not certbot_install_from_source | default(False)
 
 - import_tasks: install-from-source.yml
-  when: certbot_install_from_source
+  when: certbot_install == 'source' or certbot_install_from_source | default(False)
+
+- import_tasks: install-with-pip.yml
+  when: certbot_install in ['pip', 'pip3']
 
 - include_tasks: create-cert-standalone.yml
   with_items: "{{ certbot_certs }}"


### PR DESCRIPTION
Use-case: I want to use cloudflare-dns plugin which is available through pip, but incompatible with certbot package version. I find source installation "overkill" on a production server.
I tried to simplify source handling using only one variable while keeping backward compatibility.
