### PR TITLE
Consider standalone in renewal

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,7 @@ certbot_auto_renew_user: "{{ ansible_user }}"
 certbot_auto_renew_hour: 3
 certbot_auto_renew_minute: 30
 certbot_auto_renew_options: "--quiet --no-self-upgrade"
+certbot_auto_renew_script_path: /opt/certbot-auto-renew-script.sh
 
 # Parameters used when creating new Certbot certs.
 certbot_create_if_missing: no

--- a/files/certbot-auto-renew-script.j2
+++ b/files/certbot-auto-renew-script.j2
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+{% for serv in certbot_standalone_stop_services %}
+service {{ serv }} stop
+{% endfor %}
+
+{{ certbot_script }} renew {{ certbot_auto_renew_options }}
+
+{% for serv in certbot_standalone_stop_services %}
+service {{ serv }} start
+{% endfor %}

--- a/tasks/renew-cron.yml
+++ b/tasks/renew-cron.yml
@@ -1,8 +1,15 @@
 ---
+- name: Create certbot renewal script.
+  template:
+    src: files/certbot-auto-renew-script.j2
+    dest: /opt/certbot-auto-renew-script.sh
+    owner: "{{ certbot_auto_renew_user }}"
+    mode: 0744
+
 - name: Add cron job for certbot renewal (if configured).
   cron:
     name: Certbot automatic renewal.
-    job: "{{ certbot_script }} renew {{ certbot_auto_renew_options }}"
+    job: "/opt/certbot-auto-renew-script.sh"
     minute: "{{ certbot_auto_renew_minute }}"
     hour: "{{ certbot_auto_renew_hour }}"
     user: "{{ certbot_auto_renew_user }}"

--- a/tasks/renew-cron.yml
+++ b/tasks/renew-cron.yml
@@ -2,14 +2,14 @@
 - name: Create certbot renewal script.
   template:
     src: files/certbot-auto-renew-script.j2
-    dest: /opt/certbot-auto-renew-script.sh
+    dest: "{{ certbot_auto_renew_script_path }}"
     owner: "{{ certbot_auto_renew_user }}"
     mode: 0744
 
 - name: Add cron job for certbot renewal (if configured).
   cron:
     name: Certbot automatic renewal.
-    job: "/opt/certbot-auto-renew-script.sh"
+    job: "{{ certbot_auto_renew_script_path }}"
     minute: "{{ certbot_auto_renew_minute }}"
     hour: "{{ certbot_auto_renew_hour }}"
     user: "{{ certbot_auto_renew_user }}"


### PR DESCRIPTION
This PR ads support for stopping and starting services in a renewal crontab script if any services are listed in `certbot_standalone_stop_services`. It does this by:
1. Generating a shell script that stops all services listed in `certbot_standalone_stop_services`, running the certbot renew command, than starting all services back up.
2. Replacing the `cron` role’s job to point to the shell script created above.

Additionally, it adds an optional `certbot_auto_renew_script_path` variable in case the default is not desired. Is there any value to documenting this variable? If so, where in the `README.md` would be most appropriate.

I don’t know how to write tests for Ansible, so any guidance would be appreciated.