### PR TITLE
Allow renew-cron to remove cronjob if it was added earlier

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,4 +16,3 @@
     loop_var: cert_item
 
 - import_tasks: renew-cron.yml
-  when: certbot_auto_renew

--- a/tasks/renew-cron.yml
+++ b/tasks/renew-cron.yml
@@ -6,3 +6,4 @@
     minute: "{{ certbot_auto_renew_minute }}"
     hour: "{{ certbot_auto_renew_hour }}"
     user: "{{ certbot_auto_renew_user }}"
+    state: "{{ 'present' if certbot_auto_renew else 'absent' }}"


### PR DESCRIPTION
If the `certbot_auto_renew` variable was `True`, and the cronjob was
added, setting it to `False` would not remove it. By always including
the `renew-cron.yml` task file, and instead checking the
`certbot_auto_renew` value there, and pick a value for `state` based on
it, we can clean up a cronjob if it is no longer wanted.