### PR TITLE
Allow installing from source using certbot-auto URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,18 +62,20 @@ These services will only be stopped the first time a new cert is generated.
 
 ### Source Installation from Git
 
-You can install Certbot from it's Git source repository if desired. This might be useful in several cases, but especially when older distributions don't have Certbot packages available (e.g. CentOS < 7, Ubuntu < 16.10 and Debian < 8).
+You can install Certbot from it's Git source repository or URL if desired. This might be useful in several cases, but especially when older distributions don't have Certbot packages available (e.g. CentOS < 7, Ubuntu < 16.10 and Debian < 8).
 
     certbot_install_from_source: false
+    certbot_install_from_source_method: 'git'  # git, url
     certbot_repo: https://github.com/certbot/certbot.git
     certbot_version: master
+    certbot_source_url: 'https://dl.eff.org/certbot-auto'
     certbot_keep_updated: true
 
-Certbot Git repository options. To install from source, set `certbot_install_from_source` to `yes`. This clones the configured `certbot_repo`, respecting the `certbot_version` setting. If `certbot_keep_updated` is set to `yes`, the repository is updated every time this role runs.
+Certbot install from source options. To install from source using Git, set `certbot_install_from_source` to `yes` and `certbot_install_from_source_method to `git`.  This clones the configured `certbot_repo`, respecting the `certbot_version` setting. To install from source using a URL set `certbot_install_from_source` to `yes` and `certbot_install_from_source_method` to `url`.  This downloads the certbot-auto script from the configured `certbot_source_url`.  If `certbot_keep_updated` is set to `yes`, the repository/download is updated every time this role runs.
 
     certbot_dir: /opt/certbot
 
-The directory inside which Certbot will be cloned.
+The directory inside which Certbot will be cloned / downloaded.
 
 ### Wildcard Certificates
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -30,8 +30,10 @@ certbot_create_standalone_stop_services:
 # To install from source (on older OSes or if you need a specific or newer
 # version of Certbot), set this variable to `yes` and configure other options.
 certbot_install_from_source: false
+certbot_install_from_source_method: 'git'  # git, url
 certbot_repo: https://github.com/certbot/certbot.git
 certbot_version: master
+certbot_source_url: 'https://raw.githubusercontent.com/certbot/certbot/{{ certbot_version }}/certbot-auto'
 certbot_keep_updated: true
 
 # Where to put Certbot when installing from source.

--- a/molecule/default/playbook-source-install-git.yml
+++ b/molecule/default/playbook-source-install-git.yml
@@ -1,0 +1,26 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+
+  vars:
+    certbot_install_from_source: true
+    certbot_auto_renew_user: root
+
+  pre_tasks:
+    - name: Update apt cache.
+      apt: update_cache=yes cache_valid_time=600
+      when: ansible_os_family == 'Debian'
+      changed_when: false
+
+    - name: Install cron (RedHat).
+      yum: name=cronie state=present
+      when: ansible_os_family == 'RedHat'
+
+    - name: Install cron (Debian).
+      apt: name=cron state=present
+      when: ansible_os_family == 'Debian'
+
+  roles:
+    - geerlingguy.git
+    - geerlingguy.certbot

--- a/molecule/default/playbook-source-install-url.yml
+++ b/molecule/default/playbook-source-install-url.yml
@@ -1,0 +1,26 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+
+  vars:
+    certbot_install_from_source: true
+    certbot_install_from_source_method: 'url'
+    certbot_auto_renew_user: root
+
+  pre_tasks:
+    - name: Update apt cache.
+      apt: update_cache=yes cache_valid_time=600
+      when: ansible_os_family == 'Debian'
+      changed_when: false
+
+    - name: Install cron (RedHat).
+      yum: name=cronie state=present
+      when: ansible_os_family == 'RedHat'
+
+    - name: Install cron (Debian).
+      apt: name=cron state=present
+      when: ansible_os_family == 'Debian'
+
+  roles:
+    - geerlingguy.certbot

--- a/tasks/install-from-source-git.yml
+++ b/tasks/install-from-source-git.yml
@@ -1,0 +1,8 @@
+---
+- name: Clone Certbot into configured directory.
+  git:
+    repo: "{{ certbot_repo }}"
+    dest: "{{ certbot_dir }}"
+    version: "{{ certbot_version }}"
+    update: "{{ certbot_keep_updated }}"
+    force: true

--- a/tasks/install-from-source-url.yml
+++ b/tasks/install-from-source-url.yml
@@ -1,0 +1,11 @@
+---
+- name: Create Certbot directory
+  file:
+    path: "{{ certbot_dir }}"
+    state: "directory"
+
+- name: Download Certbot into configured directory
+  get_url:
+    url: "{{ certbot_source_url }}"
+    dest: "{{ certbot_script }}"
+    force: "{{ certbot_keep_updated }}"

--- a/tasks/install-from-source.yml
+++ b/tasks/install-from-source.yml
@@ -1,15 +1,13 @@
 ---
-- name: Clone Certbot into configured directory.
-  git:
-    repo: "{{ certbot_repo }}"
-    dest: "{{ certbot_dir }}"
-    version: "{{ certbot_version }}"
-    update: "{{ certbot_keep_updated }}"
-    force: true
-
 - name: Set Certbot script variable.
   set_fact:
     certbot_script: "{{ certbot_dir }}/certbot-auto"
+
+- import_tasks: 'install-from-source-git.yml'
+  when: certbot_install_from_source_method == 'git'
+
+- import_tasks: 'install-from-source-url.yml'
+  when: certbot_install_from_source_method == 'url'
 
 - name: Ensure certbot-auto is executable.
   file:


### PR DESCRIPTION
fully backwards compatible so it won't break/change any existing systems