### PR TITLE
Add cloud-init create method

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -36,3 +36,7 @@ certbot_keep_updated: true
 
 # Where to put Certbot when installing from source.
 certbot_dir: /opt/certbot
+
+# When certbot_create_method==cloud-init, test certificates will be installed
+# that can be used by a server (eg. nginx)
+certbot_cloud_init_test_certificates: true

--- a/tasks/create-cert-cloud-init.yml
+++ b/tasks/create-cert-cloud-init.yml
@@ -1,0 +1,21 @@
+---
+- name: Check if certificate already exists.
+  stat:
+    path: /etc/letsencrypt/live/{{ cert_item.domains | first | replace('*.', '') }}/cert.pem
+  register: letsencrypt_cert
+
+- name: Ensure cloud-init directory exists.
+  file:
+    path: /var/lib/cloud/scripts/per-instance
+    state: directory
+
+- name: Ensure cloud-init creates certificates.
+  template:
+    src: certbot-init.sh.j2
+    dest: "/var/lib/cloud/scripts/per-instance/certbot-init-{{ cert_item.domains | first | replace('*.', '') }}.sh"
+
+- name: Ensure test certificates are created.
+  command: "{{ certbot_create_command }} --test-cert"
+  when:
+    - not letsencrypt_cert.stat.exists
+    - certbot_cloud_init_test_certificates

--- a/tasks/create-cert-cloud-init.yml
+++ b/tasks/create-cert-cloud-init.yml
@@ -13,6 +13,7 @@
   template:
     src: certbot-init.sh.j2
     dest: "/var/lib/cloud/scripts/per-instance/certbot-init-{{ cert_item.domains | first | replace('*.', '') }}.sh"
+    mode: +rx
 
 - name: Ensure test certificates are created.
   command: "{{ certbot_create_command }} --test-cert"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,5 +15,13 @@
   loop_control:
     loop_var: cert_item
 
+- include_tasks: create-cert-cloud-init.yml
+  with_items: "{{ certbot_certs }}"
+  when:
+    - certbot_create_if_missing
+    - certbot_create_method == 'cloud-init'
+  loop_control:
+    loop_var: cert_item
+
 - import_tasks: renew-cron.yml
   when: certbot_auto_renew

--- a/templates/certbot-init.sh.j2
+++ b/templates/certbot-init.sh.j2
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -e
+
+{{ certbot_create_command }}


### PR DESCRIPTION
I'm using this role to provision images with Packer. As I'm running the standalone create method over and over again, I was hitting the rate-limit.

With this method I can provision the images with a test certificate and inject a script into cloud-init to request the real certificate when the image goes into the real world.