### PR TITLE
create pre and post hooks

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,6 +21,12 @@ certbot_create_command: >-
   {{ certbot_script }} certonly --standalone --noninteractive --agree-tos
   --email {{ cert_item.email | default(certbot_admin_email) }}
   -d {{ cert_item.domains | join(',') }}
+  {{ '--pre-hook /etc/letsencrypt/renewal-hooks/pre/stop_services'
+    if certbot_create_standalone_stop_services
+  else '' }}
+  {{ '--post-hook /etc/letsencrypt/renewal-hooks/post/start_services'
+    if certbot_create_standalone_stop_services
+  else '' }}
 
 certbot_create_standalone_stop_services:
   - nginx

--- a/tasks/create-cert-standalone.yml
+++ b/tasks/create-cert-standalone.yml
@@ -22,7 +22,9 @@
     owner: root
     group: root
     mode: 0750
-  when: certbot_create_standalone_stop_services is defined and certbot_create_standalone_stop_services
+  when:
+    - certbot_create_standalone_stop_services is defined
+    - certbot_create_standalone_stop_services
 
 - name: create post hook to start services
   template:

--- a/tasks/create-cert-standalone.yml
+++ b/tasks/create-cert-standalone.yml
@@ -33,7 +33,9 @@
     owner: root
     group: root
     mode: 0750
-  when: certbot_create_standalone_stop_services is defined and certbot_create_standalone_stop_services
+  when:
+    - certbot_create_standalone_stop_services is defined
+    - certbot_create_standalone_stop_services
 
 - name: Generate new certificate if one doesn't exist.
   command: "{{ certbot_create_command }}"

--- a/tasks/create-cert-standalone.yml
+++ b/tasks/create-cert-standalone.yml
@@ -4,20 +4,35 @@
     path: /etc/letsencrypt/live/{{ cert_item.domains | first | replace('*.', '') }}/cert.pem
   register: letsencrypt_cert
 
-- name: Stop services to allow certbot to generate a cert.
-  service:
-    name: "{{ item }}"
-    state: stopped
-  when: not letsencrypt_cert.stat.exists
-  with_items: "{{ certbot_create_standalone_stop_services }}"
+- name: create pre and post hook folders because those don't exist yet on a fresh install
+  file:
+    path: /etc/letsencrypt/renewal-hooks/{{ item }}
+    state: directory
+    mode: 0755
+    owner: root
+    group: root
+  with_items:
+    - pre
+    - post
+
+- name: Create pre hook to stop services
+  template:
+    src: stop_services.j2
+    dest: /etc/letsencrypt/renewal-hooks/pre/stop_services
+    owner: root
+    group: root
+    mode: 0750
+  when: certbot_create_standalone_stop_services is defined and certbot_create_standalone_stop_services
+
+- name: create post hook to start services
+  template:
+    src: start_services.j2
+    dest: /etc/letsencrypt/renewal-hooks/post/start_services
+    owner: root
+    group: root
+    mode: 0750
+  when: certbot_create_standalone_stop_services is defined and certbot_create_standalone_stop_services
 
 - name: Generate new certificate if one doesn't exist.
   command: "{{ certbot_create_command }}"
   when: not letsencrypt_cert.stat.exists
-
-- name: Start services after cert has been generated.
-  service:
-    name: "{{ item }}"
-    state: started
-  when: not letsencrypt_cert.stat.exists
-  with_items: "{{ certbot_create_standalone_stop_services }}"

--- a/templates/start_services.j2
+++ b/templates/start_services.j2
@@ -1,0 +1,15 @@
+#!/bin/bash
+# {{ ansible_managed }}
+
+{% for item in certbot_create_standalone_stop_services %}
+echo "starting service {{ item }}"
+{% if ansible_service_mgr == 'systemd' %}
+systemctl start {{ item }}
+{% elif ansible_service_mgr == 'upstart' %}
+initctl start {{ item }}
+{% elif ansible_service_mgr == 'openrc' %}
+rc-service {{ item }} start
+{% else %}
+service {{ item }} start
+{% endif %}
+{% endfor %}

--- a/templates/stop_services.j2
+++ b/templates/stop_services.j2
@@ -1,0 +1,15 @@
+#!/bin/bash
+# {{ ansible_managed }}
+
+{% for item in certbot_create_standalone_stop_services %}
+echo "stopping service {{ item }}"
+{% if ansible_service_mgr == 'systemd' %}
+systemctl stop {{ item }}
+{% elif ansible_service_mgr == 'upstart' %}
+initctl stop {{ item }}
+{% elif ansible_service_mgr == 'openrc' %}
+rc-service {{ item }} stop
+{% else %}
+service {{ item }} stop
+{% endif %}
+{% endfor %}


### PR DESCRIPTION
Cleaned up version of pr 75.

* Move 'stop' services to pre-hook and post-hook. This way they will also be stopped and started when renewing.

- remove service stop/start tasks
- add pre-hook/post-hook templates
- add pre-hook/pos-hook template tasks
- create missing directories at first run
- run pre and post hook during first manual run