### PR TITLE
Add option to install from pypi

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,6 +27,7 @@ certbot_create_standalone_stop_services:
   # - apache
   # - varnish
 
+certbot_install_from_pypi: no
 certbot_pypi_version: latest
 
 # To install from source (on older OSes or if you need a specific or newer

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,6 +27,8 @@ certbot_create_standalone_stop_services:
   # - apache
   # - varnish
 
+certbot_pypi_version: latest
+
 # To install from source (on older OSes or if you need a specific or newer
 # version of Certbot), set this variable to `yes` and configure other options.
 certbot_install_from_source: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,7 +27,7 @@ certbot_create_standalone_stop_services:
   # - apache
   # - varnish
 
-certbot_install_from_pypi: no
+certbot_install_from_pypi: false
 certbot_pypi_version: latest
 
 # To install from source (on older OSes or if you need a specific or newer

--- a/tasks/install-from-pypi.yml
+++ b/tasks/install-from-pypi.yml
@@ -4,7 +4,7 @@
     - certbot_pypi_version == "latest"
   pip:
     name: "{{ item }}"
-    state: latest
+    state: "{{ certbot_pypi_version }}"
   with_items:
     - certbot
     - certbot-nginx

--- a/tasks/install-from-pypi.yml
+++ b/tasks/install-from-pypi.yml
@@ -1,0 +1,25 @@
+---
+- name: Install latest Certbot from pypi
+  when:
+    - certbot_pypi_version == "latest"
+  pip:
+    name: "{{ item }}"
+    state: latest
+  with_items:
+    - certbot
+    - certbot-nginx
+
+- name: Install latest Certbot from pypi
+  when:
+    - certbot_pypi_version != "latest"
+  pip:
+    name: "{{ item }}"
+    state: present
+    version: "{{ certbot_pypi_version }}"
+  with_items:
+    - certbot
+    - certbot-nginx
+
+- name: Set Certbot script variable.
+  set_fact:
+    certbot_script: "/usr/local/bin/certbot"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,7 +11,9 @@
     - certbot
 
 - import_tasks: install-from-source.yml
-  when: certbot_install_from_source
+  when:
+    - certbot_install_from_source
+    - not certbot_install_from_pypi
   tags:
     - certbot
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,11 +1,26 @@
 ---
 - import_tasks: include-vars.yml
+  tags:
+    - certbot
 
 - import_tasks: install-with-package.yml
-  when: not certbot_install_from_source
+  when:
+    - not certbot_install_from_source
+    - not certbot_install_from_pypi
+  tags:
+    - certbot
 
 - import_tasks: install-from-source.yml
   when: certbot_install_from_source
+  tags:
+    - certbot
+
+- import_tasks: install-from-pypi.yml
+  when:
+    - not certbot_install_from_source
+    - certbot_install_from_pypi
+  tags:
+    - certbot
 
 - include_tasks: create-cert-standalone.yml
   with_items: "{{ certbot_certs }}"
@@ -14,6 +29,10 @@
     - certbot_create_method == 'standalone'
   loop_control:
     loop_var: cert_item
+  tags:
+    - certbot
 
 - import_tasks: renew-cron.yml
   when: certbot_auto_renew
+  tags:
+    - certbot


### PR DESCRIPTION
Proposing this as an alternative to https://github.com/geerlingguy/ansible-role-certbot/pull/52

There are two advantages to this approach:

* It's not a backwards-incompatible change since rather than changing `certbot_install_from_source` -> `certbot_install` it adds a new variable `certbot_install_from_pypi`, thus retaining the previous configuration interface.
* It enables users to pin their certbot pypi package(s) to a particular version.

Additionally, this PR adds the `certbot` tag to all tasks.