### PR TITLE
Resolve ansible deprecation warnings

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,10 +2,10 @@
 - import_tasks: include-vars.yml
 
 - import_tasks: install-with-package.yml
-  when: not certbot_install_from_source
+  when: not certbot_install_from_source | bool
 
 - import_tasks: install-from-source.yml
-  when: certbot_install_from_source
+  when: certbot_install_from_source | bool
 
 - include_tasks: create-cert-standalone.yml
   with_items: "{{ certbot_certs }}"
@@ -16,4 +16,4 @@
     loop_var: cert_item
 
 - import_tasks: renew-cron.yml
-  when: certbot_auto_renew
+  when: certbot_auto_renew | bool


### PR DESCRIPTION
Ansible version 2.8.0 yields these type of deprecation warnings:
```
TASK [ : APT_KEY | --- ****************************
[DEPRECATION WARNING]: evaluating var as a bare variable,
this behaviour will go away and you might need to add |bool to the expression
in the future. Also see CONDITIONAL_BARE_VARS configuration toggle.. This
feature will be removed in version 2.12. Deprecation warnings can be disabled
by setting deprecation_warnings=False in ansible.cfg.
```