### PR TITLE
Adding Apache's plugin support

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,10 +4,12 @@ certbot_auto_renew: true
 certbot_auto_renew_user: "{{ ansible_user | default(lookup('env', 'USER')) }}"
 certbot_auto_renew_hour: 3
 certbot_auto_renew_minute: 30
-certbot_auto_renew_options: "--quiet --no-self-upgrade"
+certbot_auto_renew_options: "--config-dir {{ certbot_config_dir }}
+  --{{ certbot_create_method }} --quiet --no-self-upgrade"
 
 # Parameters used when creating new Certbot certs.
 certbot_create_if_missing: false
+# Supported methods: standalone and apache
 certbot_create_method: standalone
 certbot_admin_email: email@example.com
 certbot_certs: []
@@ -18,8 +20,9 @@ certbot_certs: []
 # - domains:
 #     - example3.com
 certbot_create_command: >-
-  {{ certbot_script }} certonly --standalone --noninteractive --agree-tos
-  --email {{ cert_item.email | default(certbot_admin_email) }}
+  {{ certbot_script }} --config-dir {{ certbot_config_dir }}
+  certonly --{{ certbot_create_method }} --noninteractive
+  --agree-tos --email {{ cert_item.email | default(certbot_admin_email) }}
   -d {{ cert_item.domains | join(',') }}
 
 certbot_create_standalone_stop_services:
@@ -36,3 +39,9 @@ certbot_keep_updated: true
 
 # Where to put Certbot when installing from source.
 certbot_dir: /opt/certbot
+
+# Certbot extra Packages (To install additional packages like certbot-apache)
+certbot_extra_packages: ""
+
+# Certbot config directory
+certbot_config_dir: /etc/letsencrypt

--- a/tasks/create-cert-apache.yml
+++ b/tasks/create-cert-apache.yml
@@ -1,0 +1,9 @@
+---
+- name: Check if certificate already exists.
+  stat:
+    path: "{{ certbot_config_dir }}/live/{{ cert_item.domains | first | replace('*.', '') }}/cert.pem"
+  register: letsencrypt_cert
+
+- name: Generate new certificate if one doesn't exist.
+  command: "{{ certbot_create_command }}"
+  when: not letsencrypt_cert.stat.exists

--- a/tasks/create-cert-standalone.yml
+++ b/tasks/create-cert-standalone.yml
@@ -1,7 +1,7 @@
 ---
 - name: Check if certificate already exists.
   stat:
-    path: /etc/letsencrypt/live/{{ cert_item.domains | first | replace('*.', '') }}/cert.pem
+    path: "{{ certbot_config_dir }}/live/{{ cert_item.domains | first | replace('*.', '') }}/cert.pem"
   register: letsencrypt_cert
 
 - name: Stop services to allow certbot to generate a cert.

--- a/tasks/install-with-package.yml
+++ b/tasks/install-with-package.yml
@@ -2,6 +2,10 @@
 - name: Install Certbot.
   package: "name={{ certbot_package }} state=present"
 
+- name: Install Certbot Extra Packages.
+  package: "name={{ certbot_extra_packages }} state=present"
+  when: certbot_extra_packages | length > 0
+
 - name: Set Certbot script variable.
   set_fact:
     certbot_script: "{{ certbot_package }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,5 +15,13 @@
   loop_control:
     loop_var: cert_item
 
+- include_tasks: create-cert-apache.yml
+  with_items: "{{ certbot_certs }}"
+  when:
+    - certbot_create_if_missing
+    - certbot_create_method == 'apache'
+  loop_control:
+    loop_var: cert_item
+
 - import_tasks: renew-cron.yml
   when: certbot_auto_renew


### PR DESCRIPTION
This plugin supports issuing/renewing certificates without needing
to stop/start Apache's daemon.

This change also adds a variable to allow override default letsencrypt
config directory (/etc/letsencrypt).

It is in a state that "works for me". As far I was able to test, it doesn't break the standard behaviour.

I can provide additional changes/tests if needed.