### PR TITLE
Add option to use test certs.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,7 @@ certbot_auto_renew_minute: 30
 certbot_auto_renew_options: "--quiet --no-self-upgrade"
 
 # Parameters used when creating new Certbot certs.
+certbot_dry_run: false
 certbot_create_if_missing: false
 certbot_create_method: standalone
 certbot_admin_email: email@example.com
@@ -20,7 +21,7 @@ certbot_certs: []
 certbot_create_command: >-
   {{ certbot_script }} certonly --standalone --noninteractive --agree-tos
   --email {{ cert_item.email | default(certbot_admin_email) }}
-  -d {{ cert_item.domains | join(',') }}
+  -d {{ cert_item.domains | join(',') }} {{ "--dry-run" if certbot_dry_run }}
 
 certbot_create_standalone_stop_services:
   - nginx

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,7 +7,7 @@ certbot_auto_renew_minute: 30
 certbot_auto_renew_options: "--quiet --no-self-upgrade"
 
 # Parameters used when creating new Certbot certs.
-certbot_dry_run: false
+certbot_test_cert: false
 certbot_create_if_missing: false
 certbot_create_method: standalone
 certbot_admin_email: email@example.com
@@ -21,7 +21,7 @@ certbot_certs: []
 certbot_create_command: >-
   {{ certbot_script }} certonly --standalone --noninteractive --agree-tos
   --email {{ cert_item.email | default(certbot_admin_email) }}
-  -d {{ cert_item.domains | join(',') }} {{ "--dry-run" if certbot_dry_run }}
+  -d {{ cert_item.domains | join(',') }} {{ "--test-cert" if certbot_test_cert }}
 
 certbot_create_standalone_stop_services:
   - nginx


### PR DESCRIPTION
Use test certificates during development in order to avoid rate limit errors on frequent redeploys.
ref: https://letsencrypt.org/docs/rate-limits/