### PR TITLE
use nginx plugin for cert renewal

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,7 @@ certbot_auto_renew: true
 certbot_auto_renew_user: "{{ ansible_user | default(lookup('env', 'USER')) }}"
 certbot_auto_renew_hour: "3"
 certbot_auto_renew_minute: "30"
-certbot_auto_renew_options: "--quiet --no-self-upgrade"
+certbot_auto_renew_options: "--quiet --no-self-upgrade --nginx"
 
 # Parameters used when creating new Certbot certs.
 certbot_create_if_missing: false

--- a/tasks/install-nginx-plugin.yml
+++ b/tasks/install-nginx-plugin.yml
@@ -1,0 +1,12 @@
+---
+
+- name: Add apt repository
+  apt_repository:
+    repo: "{{ item }}"
+    state: present
+  loop: "{{ certbot_nginx_plugin_apt_repos }}"
+
+- name: Install nginx plugin
+  package:
+    name: "{{ certbot_nginx_plugin }}"
+    state: present

--- a/tasks/install-with-package.yml
+++ b/tasks/install-with-package.yml
@@ -5,3 +5,6 @@
 - name: Set Certbot script variable.
   set_fact:
     certbot_script: "{{ certbot_package }}"
+
+- import_tasks: install-nginx-plugin.yml
+  when: "certbot_auto_renew_options is search('--nginx')"

--- a/vars/Debian-9.yml
+++ b/vars/Debian-9.yml
@@ -1,0 +1,6 @@
+---
+certbot_package: certbot
+certbot_nginx_plugin: python-certbot-nginx
+certbot_nginx_plugin_apt_repos:
+  - deb http://deb.debian.org/debian stretch-backports main contrib non-free
+  - deb-src http://deb.debian.org/debian stretch-backports main contrib non-free

--- a/vars/Ubuntu-18.04.yml
+++ b/vars/Ubuntu-18.04.yml
@@ -1,5 +1,5 @@
 ---
-certbot_package: letsencrypt
+certbot_package: certbot
 certbot_nginx_plugin: python-certbot-nginx
 certbot_nginx_plugin_apt_repos:
   - ppa:certbot/certbot

--- a/vars/default.yml
+++ b/vars/default.yml
@@ -1,2 +1,4 @@
 ---
 certbot_package: certbot
+certbot_nginx_plugin: python2-certbot-nginx
+certbot_nginx_plugin_apt_repos: []


### PR DESCRIPTION
The cert renewal process fails with the current setup, when using nginx on port 80.
Since this is pretty much the default setup for this role I added the nginx certbot plugin