### PR TITLE
check service exist and open port 80

### DIFF
--- a/tasks/create-cert-standalone.yml
+++ b/tasks/create-cert-standalone.yml
@@ -4,11 +4,22 @@
     path: /etc/letsencrypt/live/{{ cert_item.domains | first | replace('*.', '') }}/cert.pem
   register: letsencrypt_cert
 
+- name: Populate service facts
+  service_facts:
+  
+- name: firewall enable port 80
+  firewalld:
+    port: 80/tcp
+    permanent: false
+    state: enabled
+  ignore_errors: yes
+  when: not letsencrypt_cert.stat.exists
+
 - name: Stop services to allow certbot to generate a cert.
   service:
     name: "{{ item }}"
     state: stopped
-  when: not letsencrypt_cert.stat.exists
+  when: not letsencrypt_cert.stat.exists and item in services
   with_items: "{{ certbot_create_standalone_stop_services }}"
 
 - name: Generate new certificate if one doesn't exist.
@@ -19,5 +30,5 @@
   service:
     name: "{{ item }}"
     state: started
-  when: not letsencrypt_cert.stat.exists
+  when: not letsencrypt_cert.stat.exists and item in services
   with_items: "{{ certbot_create_standalone_stop_services }}"


### PR DESCRIPTION
Checks the existence of the services that must be stopped.
in some cases services like nginx must be created after the certbot role because need some certificates.
therefore nginx should be stopped only on the second round of ansible