### PR TITLE
Fix link to playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ By default, this role configures a cron job to run under the provided user accou
 
 Currently there is one built-in method for generating new certificates using this role: `standalone`. Other methods (e.g. using nginx or apache and a webroot) may be added in the future.
 
-**For a complete example**: see the fully functional test playbook in [molecule/default/playbook-standalone-nginx-aws.yml](molecule/default/playbook-standalone-nginx-aws.yml).
+**For a complete example**: see the fully functional test playbook in [molecule/default/playbook-standalone-nginx-aws.yml](https://github.com/geerlingguy/ansible-role-certbot/blob/master/molecule/default/playbook-standalone-nginx-aws.yml).
 
     certbot_create_if_missing: false
     certbot_create_method: standalone


### PR DESCRIPTION
Even though the relative link works fine on GitLab, it obviously fails when browsing the project through Ansible Galaxy.