### PR TITLE
Improve configurability

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ A list of domains (and other data) for which certs should be generated. You can 
 
 The `certbot_create_command` defines the command used to generate the cert.
 
+The `certbot_etc` variable defaulting to `/etc/letsencrypt` allows using a non-standard location for Certbot configuration.
+
 #### Standalone Certificate Generation
 
     certbot_create_standalone_stop_services:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Generally, installing from source (see section `Source Installation from Git`) l
 
 ## Role Variables
 
-The variable `certbot_install_from_source` controls whether to install Certbot from Git or package management. The latter is the default, so the variable defaults to `no`.
+The variables `certbot_install_from_source` and `certbot_install_with_package` control whether to install Certbot from Git or package management. The latter is the default, and you can set both variables to `no` to use a Certbot installed outside of this role.
 
     certbot_auto_renew: true
     certbot_auto_renew_user: "{{ ansible_user | default(lookup('env', 'USER')) }}"

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ The variables `certbot_install_from_source` and `certbot_install_with_package` c
 
 By default, this role configures a cron job to run under the provided user account at the given hour and minute, every day. The defaults run `certbot renew` (or `certbot-auto renew`) via cron every day at 03:30:00 by the user you use in your Ansible playbook. It's preferred that you set a custom user/hour/minute so the renewal is during a low-traffic period and done by a non-root user account.
 
+Use the `certbot_auto_renew_cron_file` to override [which cron file](https://docs.ansible.com/ansible/latest/modules/cron_module.html#parameter-cron_file) gets updated. Defaults to empty, which means using the user's crontab. 
+
 ### Automatic Certificate Generation
 
 Currently there is one built-in method for generating new certificates using this role: `standalone`. Other methods (e.g. using nginx or apache and a webroot) may be added in the future.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,6 +27,10 @@ certbot_create_standalone_stop_services:
   # - apache
   # - varnish
 
+# To install Certbot with the OS package, set this variable to `true`.
+# If you are installing from source (see below) or manually, set this to `false`.
+certbot_install_with_package: false
+
 # To install from source (on older OSes or if you need a specific or newer
 # version of Certbot), set this variable to `yes` and configure other options.
 certbot_install_from_source: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,7 @@ certbot_auto_renew_user: "{{ ansible_user | default(lookup('env', 'USER')) }}"
 certbot_auto_renew_hour: "3"
 certbot_auto_renew_minute: "30"
 certbot_auto_renew_options: "--quiet --no-self-upgrade"
+certbot_auto_renew_cron_file:
 
 # Parameters used when creating new Certbot certs.
 certbot_etc: /etc/letsencrypt

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,7 @@ certbot_auto_renew_minute: "30"
 certbot_auto_renew_options: "--quiet --no-self-upgrade"
 
 # Parameters used when creating new Certbot certs.
+certbot_etc: /etc/letsencrypt
 certbot_create_if_missing: false
 certbot_create_method: standalone
 certbot_admin_email: email@example.com

--- a/tasks/create-cert-standalone.yml
+++ b/tasks/create-cert-standalone.yml
@@ -1,7 +1,7 @@
 ---
 - name: Check if certificate already exists.
   stat:
-    path: /etc/letsencrypt/live/{{ cert_item.domains | first | replace('*.', '') }}/cert.pem
+    path: "{{ certbot_etc }}/live/{{ cert_item.domains | first | replace('*.', '') }}/cert.pem"
   register: letsencrypt_cert
 
 - name: Stop services to allow certbot to generate a cert.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,7 @@
   when: ansible_os_family == 'RedHat'
 
 - import_tasks: install-with-package.yml
-  when: not certbot_install_from_source
+  when: certbot_install_with_package
 
 - import_tasks: install-from-source.yml
   when: certbot_install_from_source

--- a/tasks/renew-cron.yml
+++ b/tasks/renew-cron.yml
@@ -2,6 +2,7 @@
 - name: Add cron job for certbot renewal (if configured).
   cron:
     name: Certbot automatic renewal.
+    cron_file: "{{ certbot_auto_renew_cron_file }}"
     job: "{{ certbot_script }} renew {{ certbot_auto_renew_options }}"
     minute: "{{ certbot_auto_renew_minute }}"
     hour: "{{ certbot_auto_renew_hour }}"

--- a/tasks/renew-cron.yml
+++ b/tasks/renew-cron.yml
@@ -7,3 +7,4 @@
     minute: "{{ certbot_auto_renew_minute }}"
     hour: "{{ certbot_auto_renew_hour }}"
     user: "{{ certbot_auto_renew_user }}"
+  register: certbot_cron


### PR DESCRIPTION
Hey @geerlingguy! I found this role super useful for setting up Let's Encrypt on a QNAP NAS but ran into a couple of problems because this target system is sort of awkward and I had to resort to doing non-standard things. The main problems were the absence of Git, a decent Python and restrictions on `/etc`.

Anyway, I ended up running Certbot in Docker containers doing something like this:

```yaml
    certbot_script: >-
      {{ docker_bin }} run
      --rm
      --name certbot
      --volume "{{ certbot_home }}/etc:/etc/letsencrypt"
      --volume "{{ certbot_home }}/lib:/var/lib/letsencrypt"
      --volume "{{ certbot_home }}/log:/var/log/letsencrypt"
      {{ certbot_docker_image }}
```

This requires disabling both Git and package install.

I also could not use `/etc/letsencrypt` because the NAS erases `/etc` on reboot or on firmware upgrade.

The NAS also uses a specific crontab file location which needed an override and a `post_tasks` entry after successful update. 

Anyway, sharing my tweaks here, feel free to cherry-pick whatever you think can be useful for other users.