### PR TITLE
allow certificates to be expanded

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,7 +18,7 @@ certbot_certs: []
 # - domains:
 #     - example3.com
 certbot_create_command: >-
-  {{ certbot_script }} certonly --standalone --noninteractive --agree-tos
+  {{ certbot_script }} certonly --standalone --noninteractive --expand --agree-tos
   --email {{ cert_item.email | default(certbot_admin_email) }}
   -d {{ cert_item.domains | join(',') }}
 

--- a/tasks/create-cert-standalone.yml
+++ b/tasks/create-cert-standalone.yml
@@ -1,23 +1,34 @@
 ---
-- name: Check if certificate already exists.
-  stat:
-    path: /etc/letsencrypt/live/{{ cert_item.domains | first | replace('*.', '') }}/cert.pem
-  register: letsencrypt_cert
+- name: Get installed certs.
+  shell: |
+    {{ certbot_script }} certificates | grep "Domains:" | awk '{ gsub(/    Domains: /,""); print }'
+  changed_when: false
+  register: letsencrypt_certs
+
+- name: Set cert_exists to false (to check if cert exists).
+  set_fact:
+    cert_exists: false
+
+- name: Check if the cert exists.
+  set_fact:
+    cert_exists: true
+  when: cert_item.domains | sort | difference(item) == []
+  with_list: "{{ letsencrypt_certs.stdout_lines }}"
 
 - name: Stop services to allow certbot to generate a cert.
   service:
     name: "{{ item }}"
     state: stopped
-  when: not letsencrypt_cert.stat.exists
+  when: not cert_exists
   with_items: "{{ certbot_create_standalone_stop_services }}"
 
 - name: Generate new certificate if one doesn't exist.
   command: "{{ certbot_create_command }}"
-  when: not letsencrypt_cert.stat.exists
+  when: not cert_exists
 
 - name: Start services after cert has been generated.
   service:
     name: "{{ item }}"
     state: started
-  when: not letsencrypt_cert.stat.exists
+  when: not cert_exists
   with_items: "{{ certbot_create_standalone_stop_services }}"


### PR DESCRIPTION
After being a bit disappointed that I can't append to certs with this role, I thought why not try to fix it myself.

This is the solution I came up with. It should fix multiple open issues, such as #113 and #43 (which is stale). PR #50 already proposed a solution which was rejected by @geerlingguy with the reason "I don't generally like to pollute managed directories with files to track state, and that's what this seems to be doing (maintaining a list of domains in a file in the letsencrypt directories)."

This PR works without creating any files and uses only certbot, grep and awk.

Short summary of how it works:
1. Get list of existing certs and their domains (using certbot)
2. Parse that output as preperation for ansible (using grep & awk)
3. Check the cert with its domains that is supposed to exist against the list from above
4. If there is no match, create (or expand) the cert

Tested on a NixOS host running `ansible 2.9.9` and a debian 10 client.

Potential issue: This PR does not check for domains that were removed from the cert. I'm sure this is not a problem, as the function is not present anyway.