### PR TITLE
Add support for issuing fake certificates from letsencrypt staging en…

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,7 @@ certbot_auto_renew_options: "--quiet --no-self-upgrade"
 
 # Parameters used when creating new Certbot certs.
 certbot_create_if_missing: false
+certbot_staging_mode: false
 certbot_create_method: standalone
 certbot_admin_email: email@example.com
 certbot_certs: []
@@ -19,6 +20,7 @@ certbot_certs: []
 #     - example3.com
 certbot_create_command: >-
   {{ certbot_script }} certonly --standalone --noninteractive --agree-tos
+   {% if certbot_staging_mode %} --staging {% endif %}
   --email {{ cert_item.email | default(certbot_admin_email) }}
   -d {{ cert_item.domains | join(',') }}
 

--- a/tasks/delete-existing-cert.yml
+++ b/tasks/delete-existing-cert.yml
@@ -1,0 +1,29 @@
+---
+- name: Check if certificate already exists.
+  stat:
+    path: /etc/letsencrypt/live/{{ cert_item.domains | first | replace('*.', '') }}/fullchain.pem
+  register: letsencrypt_cert
+
+- name: Get information about certificate
+  openssl_certificate_info:
+    path: /etc/letsencrypt/live/{{ cert_item.domains | first | replace('*.', '') }}/fullchain.pem
+  register: letsencrypt_cert_data
+  when: letsencrypt_cert.stat.exists
+
+- name: Set letsencrypt_cert_is_fake var
+  set_fact:
+    letsencrypt_cert_is_fake: "{{ 'yes' if letsencrypt_cert_data.issuer.commonName == 'Fake LE Intermediate X1' else 'no' }}"
+  when:
+    - letsencrypt_cert.stat.exists
+
+- name: Delete existing certificates if needed
+  file:
+    path: /etc/letsencrypt/{{ item }}
+    state: absent
+  loop:
+    - "live/{{ cert_item.domains | first | replace('*.', '') }}"
+    - "archive/{{ cert_item.domains | first | replace('*.', '') }}"
+    - "renewal/{{ cert_item.domains | first | replace('*.', '') }}.conf"
+  when:
+    - letsencrypt_cert.stat.exists
+    - letsencrypt_cert_is_fake | default(false) and not certbot_staging_mode

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,6 +10,12 @@
 - import_tasks: install-from-source.yml
   when: certbot_install_from_source
 
+- include_tasks:
+    file: delete-existing-cert.yml
+  loop: "{{ certbot_certs }}"
+  loop_control:
+    loop_var: cert_item
+
 - include_tasks: create-cert-standalone.yml
   with_items: "{{ certbot_certs }}"
   when:


### PR DESCRIPTION
This PR adds support for issuing fake certificates from letsencrypt staging environment. It also deletes fake certificates when `certbot_staging_mode` variable is set to `false` to ensure that valid certificate will be issued.

Solves #23 