### PR TITLE
Only enable PowerTools on CentOS

### DIFF
--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -16,5 +16,5 @@
     changed_when: false
 
   when:
-    - ansible_os_family == 'RedHat'
+    - ansible_distribution == 'CentOS'
     - ansible_distribution_major_version | int >= 8


### PR DESCRIPTION
The PowerTools repo exists only on CentOS, but the current selector ansible_os_family == 'RedHat' also evaluates to true on Fedora and RHEL, making this role fail.

This patch switches the when statement to only evaluate to true if really running on CentOS, which I think was the intention