### PR TITLE
Use more specific services to stop/start during cert creation process

### DIFF
--- a/tasks/create-cert-standalone.yml
+++ b/tasks/create-cert-standalone.yml
@@ -9,7 +9,7 @@
     name: "{{ item }}"
     state: stopped
   when: not letsencrypt_cert.stat.exists
-  with_items: "{{ certbot_create_standalone_stop_services }}"
+  with_items: "{{ cert_item.stop_services | default(certbot_create_standalone_stop_services) }}"
 
 - name: Generate new certificate if one doesn't exist.
   command: "{{ certbot_create_command }}"
@@ -20,4 +20,4 @@
     name: "{{ item }}"
     state: started
   when: not letsencrypt_cert.stat.exists
-  with_items: "{{ certbot_create_standalone_stop_services }}"
+  with_items: "{{ cert_item.stop_services | default(certbot_create_standalone_stop_services) }}"


### PR DESCRIPTION
It adds a new `stop_services` item inside `certbot_certs`. This item is a list itself and is used to stop specific services during cert creation. If it is not declared, it defaults to the value of `certbot_create_standalone_stop_services` so the old behavior is not changed. 

This is useful when you need to stop different services depending on the certificates. For example, if you have a first certificate
that uses varnish and a second one using nginx you can have a configuration that looks like this:

```yaml
certbot_certs:
  - email: janedoe@example.com
    stop_services:
      - varnish
    domains:
      - example1.com
  - email: janedoe@example.com
    stop_services:
      - nginx
    domains:
      - example2.com
 ```

This way, you don't have to stop both varnish and nginx during cert creation process.