### PR TITLE
Support more flexible issuance and renewal options

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ Additional options to pass to `certbot` during the creation event. This is usefu
     #     - example2.com
     #   renewal_config:
     #     authenticator: webroot
-    #     webroot-path: /usr/share/nginx/html
+    #     webroot_path: /usr/share/nginx/html
+    #     renew_hook: systemctl reload nginx
     #   create_options: --server https://ca.internal/acme/acme/director
     # - domains:
     #     - example3.com

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,7 +27,8 @@ certbot_certs: []
 # - domains:
 #     - example3.com
 certbot_create_command: >-
-  {{ certbot_script }} certonly --standalone --noninteractive --agree-tos {{ cert_item.create_options | default(certbot_create_options) }}
+  {{ certbot_script }} certonly --standalone --noninteractive
+  --agree-tos {{ cert_item.create_options | default(certbot_create_options) }}
   --email {{ cert_item.email | default(certbot_admin_email) }}
   -d {{ cert_item.domains | join(',') }}
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,19 +6,28 @@ certbot_auto_renew_hour: "3"
 certbot_auto_renew_minute: "30"
 certbot_auto_renew_options: "--quiet --no-self-upgrade"
 
+# Enable the systemd timer that ships with many OS packages, instead of creating a crontab
+# If certbot_auto_renew is not set, this option has no effect
+certbot_auto_renew_use_systemd: false
+
 # Parameters used when creating new Certbot certs.
 certbot_create_if_missing: false
 certbot_create_method: standalone
+certbot_create_options: ""
 certbot_admin_email: email@example.com
 certbot_certs: []
 # - email: janedoe@example.com
 #   domains:
 #     - example1.com
 #     - example2.com
+#   renewal_config:
+#     authenticator: webroot
+#     webroot-path: /usr/share/nginx/html
+#   create_options: --server https://ca.internal/acme/acme/director
 # - domains:
 #     - example3.com
 certbot_create_command: >-
-  {{ certbot_script }} certonly --standalone --noninteractive --agree-tos
+  {{ certbot_script }} certonly --standalone --noninteractive --agree-tos {{ cert_item.create_options | default(certbot_create_options) }}
   --email {{ cert_item.email | default(certbot_admin_email) }}
   -d {{ cert_item.domains | join(',') }}
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,7 +22,8 @@ certbot_certs: []
 #     - example2.com
 #   renewal_config:
 #     authenticator: webroot
-#     webroot-path: /usr/share/nginx/html
+#     webroot_path: /usr/share/nginx/html
+#     renew_hook: systemctl restart nginx
 #   create_options: --server https://ca.internal/acme/acme/director
 # - domains:
 #     - example3.com

--- a/tasks/create-cert-standalone.yml
+++ b/tasks/create-cert-standalone.yml
@@ -28,6 +28,6 @@
     section: renewalparams
     option: "{{ item.key }}"
     value: "{{ item.value }}"
-    create: no
+    create: "no"
   loop: "{{ cert_item.renewal_config | dict2items }}"
   when: cert_item.renewal_config is defined

--- a/tasks/create-cert-standalone.yml
+++ b/tasks/create-cert-standalone.yml
@@ -21,3 +21,13 @@
     state: started
   when: not letsencrypt_cert.stat.exists
   with_items: "{{ certbot_create_standalone_stop_services }}"
+
+- name: Apply renewal configuration updates
+  ini_file:
+    path: "/etc/letsencrypt/renewal/{{ cert_item.domains | first | replace('*.', '') }}.conf"
+    section: renewalparams
+    option: "{{ item.key }}"
+    value: "{{ item.value }}"
+    create: no
+  loop: "{{ cert_item.renewal_config | dict2items }}"
+  when: cert_item.renewal_config is defined

--- a/tasks/renew-cron.yml
+++ b/tasks/renew-cron.yml
@@ -12,7 +12,5 @@
   systemd:
     name: certbot-renew.timer
     state: started
-    enabled: yes
+    enabled: "yes"
   when: certbot_auto_renew_use_systemd
-
-

--- a/tasks/renew-cron.yml
+++ b/tasks/renew-cron.yml
@@ -6,3 +6,13 @@
     minute: "{{ certbot_auto_renew_minute }}"
     hour: "{{ certbot_auto_renew_hour }}"
     user: "{{ certbot_auto_renew_user }}"
+  when: not certbot_auto_renew_use_systemd
+
+- name: Enable certbot renewal timer
+  systemd:
+    name: certbot-renew.timer
+    state: started
+    enabled: yes
+  when: certbot_auto_renew_use_systemd
+
+


### PR DESCRIPTION
This pull request adds support user-specified `certbot` options during certificate creation, altering the renewal configuration file of the generated certificate(s), and using `systemd` timers instead of `cron` jobs.

The impetus for this PR was to support using an internal CA which supports ACME, and a desire to have auto-renewals happen via `webroot` instead of stopping the web server during issuance. All added functionality defaults to values which preserve the original intent of the role, so these changes should not be breaking of existing use cases.