### PR TITLE
Ensure snapd is started immediately

### DIFF
--- a/tasks/install-with-snap.yml
+++ b/tasks/install-with-snap.yml
@@ -9,6 +9,7 @@
   systemd:
     name: snapd.socket
     enabled: true
+    state: started
 
 - name: Enable classic snap support.
   file:


### PR DESCRIPTION
Just using `enabled: true` means it will start at boot, but it won't start immediately with just that. You need `state: started` to be the equivalent of `--now`.