### PR TITLE
do not use cron when installing from distribution on Debian

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,4 +19,5 @@
     loop_var: cert_item
 
 - import_tasks: renew-cron.yml
-  when: certbot_auto_renew
+  when: certbot_auto_renew and not (ansible_os_family == 'Debian' and
+                                    certbot_install_method == 'package')


### PR DESCRIPTION
Debian distribution package provides a systemd timer for certificate auto renewal