### PR TITLE
[#151] Skip "Enable classic snap support" on Debian

### DIFF
--- a/tasks/install-with-snap.yml
+++ b/tasks/install-with-snap.yml
@@ -15,6 +15,7 @@
     src: /var/lib/snapd/snap
     dest: /snap
     state: link
+  when: ansible_os_family != "Debian"
 
 - name: Update snap after install.
   shell: snap install core; snap refresh core


### PR DESCRIPTION
Solves https://github.com/geerlingguy/ansible-role-certbot/issues/151