### PR TITLE
Ignore error of "Enable classic snap support"

### DIFF
--- a/tasks/install-with-snap.yml
+++ b/tasks/install-with-snap.yml
@@ -15,6 +15,7 @@
     src: /var/lib/snapd/snap
     dest: /snap
     state: link
+  ignore_errors: true
 
 - name: Update snap after install.
   shell: snap install core; snap refresh core


### PR DESCRIPTION
On some installations origin folder does not exist and target folder already exists