### PR TITLE
Restart stop services with handlers on first run 

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,12 +21,6 @@ certbot_create_command: >-
   {{ certbot_script }} certonly --standalone --noninteractive --agree-tos
   --email {{ cert_item.email | default(certbot_admin_email) }}
   -d {{ cert_item.domains | join(',') }}
-  {{ '--pre-hook /etc/letsencrypt/renewal-hooks/pre/stop_services'
-    if certbot_create_standalone_stop_services
-  else '' }}
-  {{ '--post-hook /etc/letsencrypt/renewal-hooks/post/start_services'
-    if certbot_create_standalone_stop_services
-  else '' }}
 
 certbot_create_standalone_stop_services:
   - nginx

--- a/tasks/create-cert-standalone.yml
+++ b/tasks/create-cert-standalone.yml
@@ -40,3 +40,11 @@
 - name: Generate new certificate if one doesn't exist.
   command: "{{ certbot_create_command }}"
   when: not letsencrypt_cert.stat.exists
+
+- name: Restart services after cert has been generated.
+  debug:
+    msg: "notify: restart {{ item }}"
+  notify: "restart {{ item }}"
+  changed_when: true
+  with_items: "{{ certbot_create_standalone_stop_services }}"
+  when: not letsencrypt_cert.stat.exists


### PR DESCRIPTION
Restart stop services with handlers on first run to handle situation where service is not yet installed.

Fixes #119