### PR TITLE
Add conditional to handle old name of PowerTools repo for CentOS 8.2.2004 and earlier

### DIFF
--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -7,13 +7,27 @@
       name: dnf-plugins-core
       state: present
 
-  - name: Enable DNF module for CentOS 8+.
-    shell: |
-      dnf config-manager --set-enabled powertools
-    args:
-      warn: false
-    register: dnf_module_enable
-    changed_when: false
+  - block:
+
+    - name: Enable DNF module for CentOS 8.3+.
+      shell: |
+        dnf config-manager --set-enabled powertools
+      args:
+        warn: false
+      register: dnf_module_enable
+      changed_when: false
+
+      when: ansible_facts['distribution_version'] is version('8.3', '>=')
+
+    - name: Enable DNF module for CentOS 8.0–8.2.
+      shell: |
+        dnf config-manager --set-enabled PowerTools
+      args:
+        warn: false
+      register: dnf_module_enable
+      changed_when: false
+
+      when: ansible_facts['distribution_version'] is version('8.2', '<=')
 
   when:
     - ansible_distribution == 'CentOS'


### PR DESCRIPTION
The name of the PowerTools repo was changed from `PowerTools` to `powertools` in CentOS 8.3.2011: [see here](https://wiki.centos.org/Manuals/ReleaseNotes/CentOS8.2011#Yum_repo_file_and_repoid_changes). This causes the "Enable DNF module for CentOS 8+" task to fail on CentOS 8.0–8.2. This PR fixes that.