### PR TITLE
Fix snap symlink task failing in initial dry-run

### DIFF
--- a/tasks/install-with-snap.yml
+++ b/tasks/install-with-snap.yml
@@ -34,6 +34,7 @@
     src: /snap/bin/certbot
     dest: /usr/bin/certbot
     state: link
+  ignore_errors: "{{ ansible_check_mode }}"
 
 - name: Set Certbot script variable.
   set_fact:


### PR DESCRIPTION
Due to the certbot package not being really installed on the initial
dry-run the symlink generation fails. The corresponding will be ignored
in check mode.

Fixes #165 