### PR TITLE
recognizing RH8 Stream version

### DIFF
--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -17,7 +17,7 @@
         register: dnf_module_enable
         changed_when: false
 
-        when: ansible_facts['distribution_version'] is version('8.3', '>=')
+        when: ansible_facts['distribution_version'] is version('8.3','>=') or ansible_facts['distribution_release'] == 'Stream'
 
       - name: Enable DNF module for CentOS 8.0–8.2.
         shell: |
@@ -27,7 +27,7 @@
         register: dnf_module_enable
         changed_when: false
 
-    when: ansible_facts['distribution_version'] is version('8.2', '<=')
+        when: ansible_facts['distribution_version'] is version('8.2','<=') and ansible_facts['distribution_release'] != 'Stream'
 
   when:
     - ansible_distribution == 'CentOS'


### PR DESCRIPTION
RH8 now supports only a Stream version, 8.1-8.3 is End-of-Life
unfortunately RH8 Stream version is wrongly recognized by this ansible role as an old version, but should be treated as 8.3+