### PR TITLE
Fix installing certbot on CentOS Stream 8

### DIFF
--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -27,8 +27,8 @@
 
   - name: Enable EPEL on CentOS 8.
     yum:
-      name: 
-       - epel-release
+      name:
+        - epel-release
       state: present
     register: dnf_module_enable
     changed_when: false

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -7,27 +7,32 @@
       name: dnf-plugins-core
       state: present
 
-  - block:
+  - name: Enable DNF module for CentOS 8.3+.
+    shell: |
+      dnf config-manager --set-enabled powertools
+    args:
+      warn: false
+    register: dnf_module_enable
+    changed_when: false
+    when: ansible_facts['distribution_version'] is version('8.3', '>=') or ansible_facts['distribution_release'] == 'Stream'
 
-      - name: Enable DNF module for CentOS 8.3+.
-        shell: |
-          dnf config-manager --set-enabled powertools
-        args:
-          warn: false
-        register: dnf_module_enable
-        changed_when: false
+  - name: Enable DNF module for CentOS 8.0–8.2.
+    shell: |
+      dnf config-manager --set-enabled PowerTools
+    args:
+      warn: false
+    register: dnf_module_enable
+    changed_when: false
+    when: ansible_facts['distribution_version'] is version('8.2', '<=') and ansible_facts['distribution_release'] != 'Stream'
 
-        when: ansible_facts['distribution_version'] is version('8.3', '>=')
-
-      - name: Enable DNF module for CentOS 8.0–8.2.
-        shell: |
-          dnf config-manager --set-enabled PowerTools
-        args:
-          warn: false
-        register: dnf_module_enable
-        changed_when: false
-
-    when: ansible_facts['distribution_version'] is version('8.2', '<=')
+  - name: Enable EPEL on CentOS 8.
+    yum:
+      name: 
+       - epel-release
+      state: present
+    register: dnf_module_enable
+    changed_when: false
+    when: ansible_facts['distribution_release'] == 'Stream'
 
   when:
     - ansible_distribution == 'CentOS'


### PR DESCRIPTION
CentOS Stream 8 has Certbot located in EPEL, not in the powertools repository. There is an EPEL package in powertools, so this adds some conditions to enable EPEL when the OS is CentOS Stream. I removed the block the other ones were located in since there's now 3 conditions so this is much more readable