### PR TITLE
Add "--expand" option for Certbot

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -35,7 +35,7 @@ certbot_create_command: >-
   --email {{ cert_item.email | default(certbot_admin_email) }}
   {{ '--webroot-path ' if certbot_create_method == 'webroot'  else '' }}
   {{ cert_item.webroot | default(certbot_webroot) if certbot_create_method == 'webroot' else '' }}
-  -d {{ cert_item.domains | join(',') }}
+  --domains {{ cert_item.domains | join(',') }} --expand
   {{ '--pre-hook /etc/letsencrypt/renewal-hooks/pre/stop_services'
     if certbot_create_standalone_stop_services
   else '' }}

--- a/tasks/check-existence.yml
+++ b/tasks/check-existence.yml
@@ -1,0 +1,16 @@
+---
+- name: Get installed certificates.
+  shell: |
+    {{ certbot_script }} certificates | grep "Domains:" | awk '{ gsub(/    Domains: /,""); print }'
+  changed_when: false
+  register: letsencrypt_certs
+
+- name: Set cert_exists to false (to check if cert exists).
+  set_fact:
+    cert_exists: false
+
+- name: Check if certificate already exists.
+  set_fact:
+    cert_exists: true
+  when: cert_item.domains | sort | difference(item) == []
+  with_list: "{{ letsencrypt_certs.stdout_lines }}"

--- a/tasks/check-existence.yml
+++ b/tasks/check-existence.yml
@@ -1,7 +1,6 @@
 ---
 - name: Get installed certificates.
-  shell: |
-    {{ certbot_script }} certificates | grep "Domains:" | awk '{ gsub(/    Domains: /,""); print }'
+  command: "{{ certbot_script }} certificates"
   changed_when: false
   register: letsencrypt_certs
 
@@ -13,4 +12,4 @@
   set_fact:
     cert_exists: true
   when: cert_item.domains | sort | difference(item) == []
-  with_list: "{{ letsencrypt_certs.stdout_lines }}"
+  with_list: "{{ letsencrypt_certs.stdout_lines | select('match', '.*Domains:.*') | map('regex_replace', '^.*Domains: (.*)$', '\\1') }}"

--- a/tasks/create-cert-standalone.yml
+++ b/tasks/create-cert-standalone.yml
@@ -1,19 +1,5 @@
 ---
-- name: Get installed certificates.
-  shell: |
-    {{ certbot_script }} certificates | grep "Domains:" | awk '{ gsub(/    Domains: /,""); print }'
-  changed_when: false
-  register: letsencrypt_certs
-
-- name: Set cert_exists to false (to check if cert exists).
-  set_fact:
-    cert_exists: false
-
-- name: Check if certificate already exists.
-  set_fact:
-    cert_exists: true
-  when: cert_item.domains | sort | difference(item) == []
-  with_list: "{{ letsencrypt_certs.stdout_lines }}"
+- include_tasks: check-existence.yml
 
 - name: Ensure pre and post hook folders exist.
   file:

--- a/tasks/create-cert-standalone.yml
+++ b/tasks/create-cert-standalone.yml
@@ -1,8 +1,19 @@
 ---
+- name: Get installed certificates.
+  shell: |
+    {{ certbot_script }} certificates | grep "Domains:" | awk '{ gsub(/    Domains: /,""); print }'
+  changed_when: false
+  register: letsencrypt_certs
+
+- name: Set cert_exists to false (to check if cert exists).
+  set_fact:
+    cert_exists: false
+
 - name: Check if certificate already exists.
-  stat:
-    path: /etc/letsencrypt/live/{{ cert_item.domains | first | replace('*.', '') }}/cert.pem
-  register: letsencrypt_cert
+  set_fact:
+    cert_exists: true
+  when: cert_item.domains | sort | difference(item) == []
+  with_list: "{{ letsencrypt_certs.stdout_lines }}"
 
 - name: Ensure pre and post hook folders exist.
   file:
@@ -39,4 +50,4 @@
 
 - name: Generate new certificate if one doesn't exist.
   command: "{{ certbot_create_command }}"
-  when: not letsencrypt_cert.stat.exists
+  when: not cert_exists

--- a/tasks/create-cert-webroot.yml
+++ b/tasks/create-cert-webroot.yml
@@ -1,8 +1,5 @@
 ---
-- name: Check if certificate already exists.
-  stat:
-    path: /etc/letsencrypt/live/{{ cert_item.domains | first }}/cert.pem
-  register: letsencrypt_cert
+- include_tasks: check-existence.yml
 
 - name: Create webroot directory if it doesn't exist yet
   file:
@@ -11,4 +8,4 @@
 
 - name: Generate new certificate if one doesn't exist.
   command: "{{ certbot_create_command }}"
-  when: not letsencrypt_cert.stat.exists
+  when: not cert_exists


### PR DESCRIPTION
Dear Jeff,

thank you again for sharing one of your excellent projects with the Ansible community in form of this role.

Because we want to aim at maximum [DWIM] by implementing our systems automation infrastructure with Ansible, we are in dire need of support for the `--expand` option of Certbot, using its `webroot` method. So, we picked up the contribution #117 by @ymarkus (thanks a stack!), wrapped it up and added corresponding support for `webroot`.

After that, expanding the list of `certbot_certs.domains` by another item and re-running the corresponding playbook immediately resolved the problem for us, where, beforehand, another subdomain was added to the list and the recipe was not able to pick up the change, without reporting back any kind of error.

We hope you will like the patch. Thank you for taking the time to look into this.

With kind regards,
Andreas.

/cc @w0rldart

P.S.: This patch has already been submitted with #171, but it was closed by [stale bot](https://github.com/marketplace/stale) and I wasn't able to discover how to reopen it.

[DWIM]: https://en.wikipedia.org/wiki/DWIM

---

Others also needing this: In order to install the improvements in this branch into your Ansible environment, you might either want to invoke

```shell
ansible-galaxy install git+https://github.com/cicerops/ansible-role-certbot.git,expand
```

or add this to your `requirements.yaml` file:

```yaml
roles:

  - name: geerlingguy.certbot
    src: git+https://github.com/cicerops/ansible-role-certbot
    version: expand
```
