### PR TITLE
Avoid deprecation warning on Ansible evaluating bare variables as bool

### DIFF
--- a/tasks/create-cert-standalone.yml
+++ b/tasks/create-cert-standalone.yml
@@ -24,7 +24,7 @@
     mode: 0750
   when:
     - certbot_create_standalone_stop_services is defined
-    - certbot_create_standalone_stop_services | length
+    - certbot_create_standalone_stop_services | length > 0
 
 - name: Create post hook to start services.
   template:
@@ -35,7 +35,7 @@
     mode: 0750
   when:
     - certbot_create_standalone_stop_services is defined
-    - certbot_create_standalone_stop_services | length
+    - certbot_create_standalone_stop_services | length > 0
 
 - name: Generate new certificate if one doesn't exist.
   command: "{{ certbot_create_command }}"

--- a/tasks/create-cert-standalone.yml
+++ b/tasks/create-cert-standalone.yml
@@ -24,7 +24,7 @@
     mode: 0750
   when:
     - certbot_create_standalone_stop_services is defined
-    - certbot_create_standalone_stop_services
+    - certbot_create_standalone_stop_services | length
 
 - name: Create post hook to start services.
   template:
@@ -35,7 +35,7 @@
     mode: 0750
   when:
     - certbot_create_standalone_stop_services is defined
-    - certbot_create_standalone_stop_services
+    - certbot_create_standalone_stop_services | length
 
 - name: Generate new certificate if one doesn't exist.
   command: "{{ certbot_create_command }}"


### PR DESCRIPTION
From Ansible 2.12 on Ansible won't evaluate bare varaibles as boolean. Added boolean operator to prevent deprecation.