### PR TITLE
Add install by pip

### DIFF
--- a/tasks/install-with-pip.yml
+++ b/tasks/install-with-pip.yml
@@ -1,0 +1,17 @@
+---
+- name: Install certbot system dependencies
+  package: "name=python3-pip state=present"
+
+- name: Install virtualenv
+  ansible.builtin.pip:
+    name: virtualenv
+
+- name: Install certbot from pip
+  ansible.builtin.pip:
+    name: certbot
+    virtualenv: "{{ certbot_dir }}"
+    virtualenv_command: /usr/local/bin/virtualenv
+
+- name: Set Certbot script variable.
+  set_fact:
+    certbot_script: "{{ certbot_dir }}/bin/certbot"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,6 +13,9 @@
 - import_tasks: install-from-source.yml
   when: certbot_install_method == 'source'
 
+- import_tasks: install-with-pip.yml
+  when: certbot_install_method == 'pip'
+
 - include_tasks: create-cert-standalone.yml
   with_items: "{{ certbot_certs }}"
   when:


### PR DESCRIPTION
Install certbot using pip. It's the only reliable way to get the latest version when snap is not available.