### PR TITLE
Run hooks only for standalone mode

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -37,10 +37,10 @@ certbot_create_command: >-
   {{ cert_item.webroot | default(certbot_webroot) if certbot_create_method == 'webroot' else '' }}
   -d {{ cert_item.domains | join(',') }}
   {{ '--pre-hook /etc/letsencrypt/renewal-hooks/pre/stop_services'
-    if certbot_create_method == 'standalone'
+    if certbot_create_standalone_stop_services and certbot_create_method == 'standalone'
   else '' }}
   {{ '--post-hook /etc/letsencrypt/renewal-hooks/post/start_services'
-    if certbot_create_method == 'standalone'
+    if certbot_create_standalone_stop_services and certbot_create_method == 'standalone'
   else '' }}
 
 certbot_create_standalone_stop_services:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -37,10 +37,10 @@ certbot_create_command: >-
   {{ cert_item.webroot | default(certbot_webroot) if certbot_create_method == 'webroot' else '' }}
   -d {{ cert_item.domains | join(',') }}
   {{ '--pre-hook /etc/letsencrypt/renewal-hooks/pre/stop_services'
-    if certbot_create_standalone_stop_services
+    if certbot_create_method == 'standalone'
   else '' }}
   {{ '--post-hook /etc/letsencrypt/renewal-hooks/post/start_services'
-    if certbot_create_standalone_stop_services
+    if certbot_create_method == 'standalone'
   else '' }}
 
 certbot_create_standalone_stop_services:


### PR DESCRIPTION
If the `certbot_create_method` is set to `webroot` the `stop_services` and `start_services` hook shouldn't be run.

As a workaround I had to set `certbot_create_standalone_stop_services: false` in my playbook, otherwise the task would be executed with the hooks added, even though they didn't get copied:

> Unable to find pre-hook command /etc/letsencrypt/renewal-hooks/pre/stop_services in the PATH.
