### PR TITLE
Initial support for ACME external account binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Ansible Role: Certbot (for Let's Encrypt)
+# Ansible Role: Certbot (for Let's Encrypt and others)
 
 [![CI](https://github.com/geerlingguy/ansible-role-certbot/workflows/CI/badge.svg?event=push)](https://github.com/geerlingguy/ansible-role-certbot/actions?query=workflow%3ACI)
 
-Installs and configures Certbot (for Let's Encrypt).
+Installs and configures Certbot (for Let's Encrypt and others).
 
 ## Requirements
 
@@ -155,6 +155,14 @@ You can test the auto-renewal (without actually renewing the cert) with the comm
     /opt/certbot/certbot-auto renew --dry-run
 
 See full documentation and options on the [Certbot website](https://certbot.eff.org/).
+
+## Usage with other ACME providers
+
+This role has been preliminarily tested with Sectigo certificates. Be sure that to override the following variables with your provider's ACME URL and your account's keys:
+
+    certbot_server: "https://acme.myprovider.com"
+    certbot_eab_kid: "replaceme"
+    certbot_eab_hmac: "replaceme"
 
 ## License
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,12 @@ certbot_auto_renew_hour: "3"
 certbot_auto_renew_minute: "30"
 certbot_auto_renew_options: "--quiet --no-self-upgrade"
 
+# Replace these vars when using a different provider
+certbot_server: "https://acme.myprovider.com"
+certbot_eab_kid: "replaceme"
+certbot_eab_hmac: "replaceme"
+
+# Untested
 certbot_testmode: false
 certbot_hsts: false
 
@@ -32,6 +38,8 @@ certbot_create_command: >-
   {{ '--hsts' if certbot_hsts else '' }}
   {{ '--test-cert' if certbot_testmode else '' }}
   --noninteractive --agree-tos
+  --server {{ certbot_server  }}
+  --eab-kid {{ certbot_eab_kid }} --eab-hmac-key {{ certbot_eab_hmac }}
   --email {{ cert_item.email | default(certbot_admin_email) }}
   {{ '--webroot-path ' if certbot_create_method == 'webroot'  else '' }}
   {{ cert_item.webroot | default(certbot_webroot) if certbot_create_method == 'webroot' else '' }}

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ dependencies: []
 galaxy_info:
   role_name: certbot
   author: geerlingguy
-  description: "Installs and configures Certbot (for Let's Encrypt)."
+  description: "Installs and configures Certbot (for Let's Encrypt and others)."
   company: "Midwestern Mac, LLC"
   license: "license (BSD, MIT)"
   min_ansible_version: 2.4
@@ -32,3 +32,4 @@ galaxy_info:
     - certificates
     - ssl
     - https
+    - sectigo


### PR DESCRIPTION
Hi Jeff,

I'm submitting this PR that enables the role to work with other ACME providers. It's been only tested with Sectigo, the one used by organisation, but there's nothing specific about it.