### PR TITLE
remove deprecated --no-self-upgrade flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Controls how Certbot is installed. Available options are 'package', 'snap', and 
     certbot_auto_renew_user: "{{ ansible_user | default(lookup('env', 'USER')) }}"
     certbot_auto_renew_hour: "3"
     certbot_auto_renew_minute: "30"
-    certbot_auto_renew_options: "--quiet --no-self-upgrade"
+    certbot_auto_renew_options: "--quiet"
 
 By default, this role configures a cron job to run under the provided user account at the given hour and minute, every day. The defaults run `certbot renew` (or `certbot-auto renew`) via cron every day at 03:30:00 by the user you use in your Ansible playbook. It's preferred that you set a custom user/hour/minute so the renewal is during a low-traffic period and done by a non-root user account.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,7 @@ certbot_auto_renew: true
 certbot_auto_renew_user: "{{ ansible_user | default(lookup('env', 'USER')) }}"
 certbot_auto_renew_hour: "3"
 certbot_auto_renew_minute: "30"
-certbot_auto_renew_options: "--quiet --no-self-upgrade"
+certbot_auto_renew_options: "--quiet"
 
 certbot_testmode: false
 certbot_hsts: false


### PR DESCRIPTION
Including it will generate warnings, which go out in nightly cron emails.
