### PR TITLE
Support for certbot's --deploy-hook option

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ Services that should be stopped while `certbot` runs it's own standalone server 
 
 These services will only be stopped the first time a new cert is generated.
 
+#### Deploy hook
+
+    certbot_deploy_hook:
+
+If not empty, the value of this variable will be used as the argument to certbot's --deploy-hook option.
+
 ### Snap Installation
 
 Beginning in December 2020, the Certbot maintainers decided to recommend installing Certbot from Snap rather than maintain scripts like `certbot-auto`.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -36,12 +36,15 @@ certbot_create_command: >-
   {{ '--webroot-path ' if certbot_create_method == 'webroot'  else '' }}
   {{ cert_item.webroot | default(certbot_webroot) if certbot_create_method == 'webroot' else '' }}
   -d {{ cert_item.domains | join(',') }}
+  {{ '--deploy-hook {}'.format(certbot_deploy_hook) if certbot_deploy_hook else '' }}
   {{ '--pre-hook /etc/letsencrypt/renewal-hooks/pre/stop_services'
     if certbot_create_standalone_stop_services and certbot_create_method == 'standalone'
   else '' }}
   {{ '--post-hook /etc/letsencrypt/renewal-hooks/post/start_services'
     if certbot_create_standalone_stop_services and certbot_create_method == 'standalone'
   else '' }}
+
+certbot_deploy_hook:
 
 certbot_create_standalone_stop_services:
   - nginx


### PR DESCRIPTION
Allows users of this role to pass a custom argument to certbot's --deploy-hook option.