### PR TITLE
Update setup-RedHat.yml to support for Centos 9

### DIFF
--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -23,8 +23,20 @@
       register: dnf_module_enable
       changed_when: false
 
-    when: ansible_facts['distribution_version'] is version('8.2', '<=')
+      when: ansible_facts['distribution_version'] is version('8.2', '<=')
 
   when:
   - ansible_distribution == 'CentOS'
   - ansible_distribution_major_version | int >= 8
+  - ansible_distribution_major_version | int < 9
+
+- name: Enable DNF module for CentOS 9
+  ansible.builtin.dnf:
+    name: epel-release
+    state: present
+  register: dnf_module_enable
+  changed_when: false
+
+  when:
+  - ansible_distribution == 'CentOS'
+  - ansible_distribution_major_version | int >= 9


### PR DESCRIPTION
Hi, I'm kind of new to Ansible so sorry if this is butchering your nice module ;) I needed Centos 9 support, more a Debian guy to be honest. Google told me I need the epel-release repo, what ever that is, to be able to install certbot package. So as always "this works for me", hope this helps. Btw. I never understood why register a... variable like `dnf_module_enable` and "do not use it", because I cannot find any other reference of it.

Oh and I think I fixed https://github.com/geerlingguy/ansible-role-certbot/issues/190