### PR TITLE
Support for custom Acme server

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,17 @@ Let's Encrypt supports [generating wildcard certificates](https://community.lets
 
 Michael Porter also has a walkthrough of [Creating A Let’s Encrypt Wildcard Cert With Ansible](https://www.michaelpporter.com/2018/09/creating-a-wildcard-cert-with-ansible/), specifically with Cloudflare.
 
+### Custom Acme Server
+
+When you want to connect to a different Acme server than the one provided by Let's Encrypt, this can be accomplished by setting the following parameters.
+
+Changing the Acme server can be done for all certificates with `certbot_server` and can also be configured for individual certificates.
+
+Providing your own CA can be done with the `REQUESTS_CA_BUNDLE` environment variable in `certbot_env_vars`. Subsequently this can also be configured for individual certificates.
+
+    certbot_env_vars:
+      REQUESTS_CA_BUNDLE: "/etc/ssl/certs/my_root_ca.pem"
+
 ## Dependencies
 
 None.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,7 +15,10 @@ certbot_create_if_missing: false
 certbot_create_method: standalone
 certbot_admin_email: email@example.com
 
+# Parameters for conneting to a different acme compatible CA.
+# Can be overwritten by individual per-cert settings.
 certbot_env_vars: {}
+certbot_server: ''
 
 # Default webroot, overwritten by individual per-cert webroot directories
 certbot_webroot: /var/www/letsencrypt
@@ -30,6 +33,7 @@ certbot_certs: []
 #     - example3.com
 #   env_vars:
 #     REQUESTS_CA_BUNDLE: "/etc/ssl/certs/my_root_ca.pem"
+#   server: https://ca.example.com/acme/acme/directory
 
 certbot_create_command: >-
   {{ certbot_script }} certonly --{{ certbot_create_method  }}
@@ -46,6 +50,8 @@ certbot_create_command: >-
   {{ '--post-hook /etc/letsencrypt/renewal-hooks/post/start_services'
     if certbot_create_standalone_stop_services and certbot_create_method == 'standalone'
   else '' }}
+  {{ ('--server ' + (cert_item.server | default(certbot_server)))
+    if (cert_item.server | default(certbot_server)) != '' else '' }}
 
 certbot_create_standalone_stop_services:
   - nginx

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,6 +15,8 @@ certbot_create_if_missing: false
 certbot_create_method: standalone
 certbot_admin_email: email@example.com
 
+certbot_env_vars: {}
+
 # Default webroot, overwritten by individual per-cert webroot directories
 certbot_webroot: /var/www/letsencrypt
 
@@ -26,6 +28,8 @@ certbot_certs: []
 #     - example2.com
 # - domains:
 #     - example3.com
+#   env_vars:
+#     REQUESTS_CA_BUNDLE: "/etc/ssl/certs/my_root_ca.pem"
 
 certbot_create_command: >-
   {{ certbot_script }} certonly --{{ certbot_create_method  }}

--- a/tasks/create-cert-standalone.yml
+++ b/tasks/create-cert-standalone.yml
@@ -39,4 +39,5 @@
 
 - name: Generate new certificate if one doesn't exist.
   command: "{{ certbot_create_command }}"
+  environment: "{{ cert_item.env_vars | default(certbot_env_vars) }}"
   when: not letsencrypt_cert.stat.exists

--- a/tasks/create-cert-webroot.yml
+++ b/tasks/create-cert-webroot.yml
@@ -11,4 +11,5 @@
 
 - name: Generate new certificate if one doesn't exist.
   command: "{{ certbot_create_command }}"
+  environment: "{{ cert_item.env_vars | default(certbot_env_vars) }}"
   when: not letsencrypt_cert.stat.exists


### PR DESCRIPTION
This PR adds support for connecting to custom/self-hosted Acme server.

The following variables are introduced:
- `certbot_env_vars` (global config)
- `certbot_server` (global config)
- `env_vars` (certificate config)
- `server` (certificate config)

For consistency `certbot_env_vars` and `certbot_server` will be overwritten by configuring `env_vars` and `server` on the individual certificates.

The `certbot_server` setting is for configuring the URL to a custom/self-hosted Acme server

The `certbot_env_vars` setting is for setting the path to a custom CA as this can only be done through the `REQUESTS_CA_BUNDLE` environment variable. This works like the second example of the [Ansible docs](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_environment.html) allowing for users to set their own environment variables.

Due to the new settings being empty by default this change is fully backwards compatible.