### PR TITLE
Add retry to Certbot installation with package

### DIFF
--- a/tasks/install-with-package.yml
+++ b/tasks/install-with-package.yml
@@ -1,6 +1,10 @@
 ---
 - name: Install Certbot.
   package: "name={{ certbot_package }} state=present"
+  register: certbot_installed_ok
+  delay: 5
+  retries: 5
+  until: certbot_installed_ok is success
 
 - name: Set Certbot script variable.
   set_fact:


### PR DESCRIPTION
Add a retry to the "Install Certbot." task which can fail if there is another process that has locked the package updater (e.g. `install 'certbot'' failed: E: Could not get lock /var/lib/dpkg/lock-frontend. It is held by process 11425
 (unattended-upgr)`)