### PR TITLE
Allow for certificates to be expanded to include new domains

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,6 +14,7 @@ certbot_hsts: false
 certbot_create_if_missing: false
 certbot_create_method: standalone
 certbot_admin_email: email@example.com
+certbot_expand: false
 
 # Default webroot, overwritten by individual per-cert webroot directories
 certbot_webroot: /var/www/letsencrypt
@@ -33,6 +34,7 @@ certbot_create_command: >-
   {{ '--test-cert' if certbot_testmode else '' }}
   --noninteractive --agree-tos
   --email {{ cert_item.email | default(certbot_admin_email) }}
+  {{ '--expand' if certbot_expand else '' }}
   {{ '--webroot-path ' if certbot_create_method == 'webroot'  else '' }}
   {{ cert_item.webroot | default(certbot_webroot) if certbot_create_method == 'webroot' else '' }}
   {{ certbot_create_extra_args }}

--- a/tasks/create-cert-standalone.yml
+++ b/tasks/create-cert-standalone.yml
@@ -1,9 +1,4 @@
 ---
-- name: Check if certificate already exists.
-  stat:
-    path: /etc/letsencrypt/live/{{ cert_item.domains | first | replace('*.', '') }}/cert.pem
-  register: letsencrypt_cert
-
 - name: Ensure pre and post hook folders exist.
   file:
     path: /etc/letsencrypt/renewal-hooks/{{ item }}
@@ -39,4 +34,5 @@
 
 - name: Generate new certificate if one doesn't exist.
   command: "{{ certbot_create_command }}"
-  when: not letsencrypt_cert.stat.exists
+  register: certbot_create
+  changed_when: "'no action taken' not in certbot_create.stdout"

--- a/tasks/create-cert-webroot.yml
+++ b/tasks/create-cert-webroot.yml
@@ -1,9 +1,4 @@
 ---
-- name: Check if certificate already exists.
-  stat:
-    path: /etc/letsencrypt/live/{{ cert_item.domains | first }}/cert.pem
-  register: letsencrypt_cert
-
 - name: Create webroot directory if it doesn't exist yet
   file:
     path: "{{ cert_item.webroot | default(certbot_webroot) }}"
@@ -11,4 +6,5 @@
 
 - name: Generate new certificate if one doesn't exist.
   command: "{{ certbot_create_command }}"
-  when: not letsencrypt_cert.stat.exists
+  register: certbot_create
+  changed_when: "'no action taken' not in certbot_create.stdout"


### PR DESCRIPTION
https://github.com/geerlingguy/ansible-role-certbot/issues/49 has been stale since 2020 (but somehow not closed by the stale bot), and #180 and #171 were both closed by the stale bot.

In comparison to #180, this PR only adds `--expand` if explicitly set to do it with a new var, `certbot_expand`, as well as letting certbot handle parsing of existing domains instead of handling it through ansible.

We also check if any changes were made when running `certbot` by checking if its output contains "no action taken" or not instead of trying to save any state, keeping the entire role stateless.

We removed the task "Check if certificate already exists." because as mentioned above, certbot will gracefully handle if the cert already exists, and we check for that by looking for the aforementioned string.