### PR TITLE
add nginx support

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,10 +5,10 @@ certbot_auto_renew_user: "{{ ansible_user | default(lookup('env', 'USER')) }}"
 certbot_auto_renew_hour: "3"
 certbot_auto_renew_minute: "30"
 certbot_auto_renew_options: "--quiet"
+certbot_package: certbot
 
 certbot_testmode: false
 certbot_hsts: false
-
 
 # Parameters used when creating new Certbot certs.
 certbot_create_if_missing: false

--- a/tasks/create-cert-nginx.yml
+++ b/tasks/create-cert-nginx.yml
@@ -1,0 +1,9 @@
+---
+- name: Check if certificate already exists.
+  stat:
+    path: /etc/letsencrypt/live/{{ cert_item.domains | first }}/cert.pem
+  register: letsencrypt_cert
+
+- name: Generate new certificate if one doesn't exist.
+  command: "{{ certbot_create_command }}"
+  when: not letsencrypt_cert.stat.exists

--- a/tasks/include-vars.yml
+++ b/tasks/include-vars.yml
@@ -1,8 +1,0 @@
----
-- name: Load a variable file based on the OS type, or a default if not found.
-  include_vars: "{{ item }}"
-  with_first_found:
-    - "{{ ansible_distribution }}-{{ ansible_distribution_version }}.yml"
-    - "{{ ansible_distribution }}.yml"
-    - "{{ ansible_os_family }}.yml"
-    - "default.yml"

--- a/tasks/install-with-package.yml
+++ b/tasks/install-with-package.yml
@@ -4,4 +4,4 @@
 
 - name: Set Certbot script variable.
   set_fact:
-    certbot_script: "{{ certbot_package }}"
+    certbot_script: "certbot"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,5 +29,13 @@
   loop_control:
     loop_var: cert_item
 
+- include_tasks: create-cert-nginx.yml
+  with_items: "{{ certbot_certs }}"
+  when:
+    - certbot_create_if_missing
+    - certbot_create_method == 'nginx'
+  loop_control:
+    loop_var: cert_item
+
 - import_tasks: renew-cron.yml
   when: certbot_auto_renew

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,4 @@
 ---
-- import_tasks: include-vars.yml
-
 - import_tasks: setup-RedHat.yml
   when: ansible_os_family == 'RedHat'
 

--- a/vars/Ubuntu-16.04.yml
+++ b/vars/Ubuntu-16.04.yml
@@ -1,2 +1,0 @@
----
-certbot_package: letsencrypt

--- a/vars/default.yml
+++ b/vars/default.yml
@@ -1,2 +1,0 @@
----
-certbot_package: certbot


### PR DESCRIPTION
Hey, I just made this slight modification to enable nginx support on my setup. Needed to swap the package name to 'python3-certbot-nginx' for Debian / RHEL based distributions.

Felt like contributing this back as it was a very low hanging fruit