### PR TITLE
[BUGFIX] Initialize 'certbot_create_extra_args' variable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,6 +27,8 @@ certbot_certs: []
 # - domains:
 #     - example3.com
 
+certbot_create_extra_args: ""
+
 certbot_create_command: >-
   {{ certbot_script }} certonly --{{ certbot_create_method  }}
   {{ '--hsts' if certbot_hsts else '' }}


### PR DESCRIPTION
This was introduced in 5a23e85f1cebfbc3999d896f25b99a8c2776f808 but no default variable value was added, resulting in a 'undefined variable' error

Xref https://github.com/geerlingguy/ansible-role-certbot/pull/109

See also https://github.com/geerlingguy/ansible-role-certbot/pull/109#issuecomment-1936151593

/cc @theS1LV3R @gagath