### PR TITLE
certbot_create_method 'dns-cloudflare'

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,11 @@ By default, this role configures a cron job to run under the provided user accou
 
 ### Automatic Certificate Generation
 
-Currently the `standalone` and `webroot` method are supported for generating new certificates using this role.
+Current methods supported for generating new certificates using this role:
+
+  - `standalone`
+  - `webroot`
+  - `dns-cloudflare`
 
 **For a complete example**: see the fully functional test playbook in [molecule/default/playbook-standalone-nginx-aws.yml](molecule/default/playbook-standalone-nginx-aws.yml).
 
@@ -36,7 +40,7 @@ Set `certbot_create_if_missing` to `yes` or `True` to let this role generate cer
 
     certbot_create_method: standalone
 
-Set the method used for generating certs with the `certbot_create_method` variable — current allowed values are: `standalone` or `webroot`.
+Set the method used for generating certs with the `certbot_create_method` variable — current allowed values are: `standalone`, `webroot` or 'dns-cloudflare'.
 
     certbot_testmode: false
 
@@ -85,6 +89,11 @@ This install method is currently experimental and may or may not work across all
 #### Webroot Certificate Generation
 
 When using the `webroot` creation method, a `webroot` item has to be provided for every `certbot_certs` item, specifying which directory to use for the authentication. Also, make sure your webserver correctly delivers contents from this directory.
+
+#### dns-cloudflare Certificate Generation
+
+When using the `dns-cloudflare` creation method, set `certbot_dns_cloudflare_api_token` with your Cloudflare API token.
+The process will generate a `dns-01` challenge (*DNS01*) by creating, and subsequently removing, TXT records using the Cloudflare API. See [certbot-dns-cloudflare documentation](https://certbot-dns-cloudflare.readthedocs.io/en/stable/) for details.
 
 ### Source Installation from Git
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -40,6 +40,9 @@ certbot_create_command: >-
   {{ '--webroot-path ' if certbot_create_method == 'webroot'  else '' }}
   {{ cert_item.webroot | default(certbot_webroot) if certbot_create_method == 'webroot' else '' }}
   {{ certbot_create_extra_args }}
+  {{ '--dns-cloudflare-credentials /etc/letsencrypt/dnscloudflare.ini'
+    if certbot_create_method == 'dns-cloudflare'
+  else '' }}
   --cert-name {{ cert_item_name }}
   -d {{ cert_item.domains | join(',') }}
   {{ '--expand' if certbot_expand else '' }}
@@ -57,6 +60,8 @@ certbot_create_standalone_stop_services:
   - nginx
   # - apache
   # - varnish
+
+certbot_dns_cloudflare_api_token: fakeone
 
 # Available options: 'package', 'snap', 'source'.
 certbot_install_method: 'package'

--- a/tasks/create-cert-dns-cloudflare.yml
+++ b/tasks/create-cert-dns-cloudflare.yml
@@ -1,0 +1,15 @@
+---
+- name: Determine certificate name
+  set_fact:
+    cert_item_name: "{{ cert_item.name | default(cert_item.domains | first | replace('*.', '')) }}"
+
+- name: Check if certificate already exists.
+  stat:
+    path: /etc/letsencrypt/live/{{ cert_item_name }}/cert.pem
+  register: letsencrypt_cert
+  become: true
+
+- name: Generate new certificate if one doesn't exist.
+  command: "{{ certbot_create_command }}"
+  when: not letsencrypt_cert.stat.exists
+  become: true

--- a/tasks/install-with-package.yml
+++ b/tasks/install-with-package.yml
@@ -4,6 +4,16 @@
     name: "{{ certbot_package }}"
     state: present
 
+- name: Install Certbot dependencies.
+  package:
+    name: "{{ cert_item }}"
+    state: present
+  when:
+    - certbot_create_method in certbot_create_packages
+  loop: "{{ certbot_create_packages[certbot_create_method] }}"
+  loop_control:
+    loop_var: cert_item
+
 - name: Set Certbot script variable.
   set_fact:
     certbot_script: "{{ certbot_package }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,6 +13,17 @@
 - import_tasks: install-from-source.yml
   when: certbot_install_method == 'source'
 
+- name: Cloudflare API token
+  ansible.builtin.template:
+    src: dnscloudflare.ini.j2
+    dest: "/etc/letsencrypt/dnscloudflare.ini"
+    owner: root
+    group: root
+    mode: '0600'
+  when:
+    - certbot_create_method == 'dns-cloudflare'
+  become: true
+
 - include_tasks: create-cert-standalone.yml
   with_items: "{{ certbot_certs }}"
   when:
@@ -26,6 +37,14 @@
   when:
     - certbot_create_if_missing
     - certbot_create_method == 'webroot'
+  loop_control:
+    loop_var: cert_item
+
+- include_tasks: create-cert-dns-cloudflare.yml
+  with_items: "{{ certbot_certs }}"
+  when:
+    - certbot_create_if_missing
+    - certbot_create_method == 'dns-cloudflare'
   loop_control:
     loop_var: cert_item
 

--- a/templates/dnscloudflare.ini.j2
+++ b/templates/dnscloudflare.ini.j2
@@ -1,0 +1,1 @@
+dns_cloudflare_api_token = {{ certbot_dns_cloudflare_api_token }}

--- a/vars/default.yml
+++ b/vars/default.yml
@@ -1,2 +1,5 @@
 ---
 certbot_package: certbot
+certbot_create_packages:
+  'dns-cloudflare':
+    - python3-certbot-dns-cloudflare


### PR DESCRIPTION
https://certbot-dns-cloudflare.readthedocs.io/en/stable/

Only tested with debian. It seems you can use it too with snap using ``certbot-dns-cloudflare``