### PR TITLE
Add certbot snap install channel variable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -60,6 +60,8 @@ certbot_create_standalone_stop_services:
 
 # Available options: 'package', 'snap', 'source'.
 certbot_install_method: 'package'
+# Snap install options: 'stable', 'beta', 'edge', for more see https://snapcraft.io/docs/channels
+certbot_snap_channel: 'stable'
 
 # Source install configuration.
 certbot_repo: https://github.com/certbot/certbot.git

--- a/tasks/install-with-snap.yml
+++ b/tasks/install-with-snap.yml
@@ -28,6 +28,7 @@
   snap:
     name: certbot
     classic: true
+    channel: "{{ certbot_snap_channel }}"
 
 - name: Symlink certbot into place.
   file:


### PR DESCRIPTION
Would like to add option to select snap channel when installing certbot. This was needed because sometimes there are fixes in the edge channel for example which take a while to make it to stable channel.