### PR TITLE
Consistently access facts via the ansible_facts.* namespace

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -9,7 +9,7 @@
   pre_tasks:
     - name: Update apt cache.
       apt: update_cache=yes cache_valid_time=600
-      when: ansible_os_family == 'Debian'
+      when: ansible_facts.os_family == 'Debian'
       changed_when: false
 
     - name: Install dependencies (RedHat).
@@ -18,11 +18,11 @@
           - cronie
           - epel-release
         state: present
-      when: ansible_os_family == 'RedHat'
+      when: ansible_facts.os_family == 'RedHat'
 
     - name: Install cron (Debian).
       apt: name=cron state=present
-      when: ansible_os_family == 'Debian'
+      when: ansible_facts.os_family == 'Debian'
 
   roles:
     - geerlingguy.certbot

--- a/molecule/default/playbook-snap-install.yml
+++ b/molecule/default/playbook-snap-install.yml
@@ -10,16 +10,16 @@
   pre_tasks:
     - name: Update apt cache.
       apt: update_cache=yes cache_valid_time=600
-      when: ansible_os_family == 'Debian'
+      when: ansible_facts.os_family == 'Debian'
       changed_when: false
 
     - name: Install cron (RedHat).
       yum: name=cronie state=present
-      when: ansible_os_family == 'RedHat'
+      when: ansible_facts.os_family == 'RedHat'
 
     - name: Install cron (Debian).
       apt: name=cron state=present
-      when: ansible_os_family == 'Debian'
+      when: ansible_facts.os_family == 'Debian'
 
   roles:
     - geerlingguy.git

--- a/molecule/default/playbook-source-install.yml
+++ b/molecule/default/playbook-source-install.yml
@@ -10,16 +10,16 @@
   pre_tasks:
     - name: Update apt cache.
       apt: update_cache=yes cache_valid_time=600
-      when: ansible_os_family == 'Debian'
+      when: ansible_facts.os_family == 'Debian'
       changed_when: false
 
     - name: Install cron (RedHat).
       yum: name=cronie state=present
-      when: ansible_os_family == 'RedHat'
+      when: ansible_facts.os_family == 'RedHat'
 
     - name: Install cron (Debian).
       apt: name=cron state=present
-      when: ansible_os_family == 'Debian'
+      when: ansible_facts.os_family == 'Debian'
 
   roles:
     - geerlingguy.git

--- a/molecule/default/playbook-standalone-nginx-aws.yml
+++ b/molecule/default/playbook-standalone-nginx-aws.yml
@@ -111,19 +111,19 @@
   pre_tasks:
     - name: Update apt cache.
       apt: update_cache=true cache_valid_time=600
-      when: ansible_os_family == 'Debian'
+      when: ansible_facts.os_family == 'Debian'
       changed_when: false
 
     - name: Install dependencies (RedHat).
       yum: name={{ item }} state=present
-      when: ansible_os_family == 'RedHat'
+      when: ansible_facts.os_family == 'RedHat'
       with_items:
         - cronie
         - epel-release
 
     - name: Install cron (Debian).
       apt: name=cron state=present
-      when: ansible_os_family == 'Debian'
+      when: ansible_facts.os_family == 'Debian'
 
   roles:
     - geerlingguy.certbot

--- a/tasks/include-vars.yml
+++ b/tasks/include-vars.yml
@@ -2,7 +2,7 @@
 - name: Load a variable file based on the OS type, or a default if not found.
   include_vars: "{{ item }}"
   with_first_found:
-    - "{{ ansible_distribution }}-{{ ansible_distribution_version }}.yml"
-    - "{{ ansible_distribution }}.yml"
-    - "{{ ansible_os_family }}.yml"
+    - "{{ ansible_facts.distribution }}-{{ ansible_facts.distribution_version }}.yml"
+    - "{{ ansible_facts.distribution }}.yml"
+    - "{{ ansible_facts.os_family }}.yml"
     - "default.yml"

--- a/tasks/install-with-snap.yml
+++ b/tasks/install-with-snap.yml
@@ -16,7 +16,7 @@
     src: /var/lib/snapd/snap
     dest: /snap
     state: link
-  when: ansible_os_family != "Debian"
+  when: ansible_facts.os_family != "Debian"
 
 - name: Update snap after install.
   shell: snap install core; snap refresh core

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,7 @@
 - import_tasks: include-vars.yml
 
 - import_tasks: setup-RedHat.yml
-  when: ansible_os_family == 'RedHat'
+  when: ansible_facts.os_family == 'RedHat'
 
 - import_tasks: install-with-package.yml
   when: certbot_install_method == 'package'


### PR DESCRIPTION
Currently, the role failed to run with `INJECT_FACTS_AS_VARS` set to `False` as the required `ansible_*` variables are not defined.

The configuration variable `INJECT_FACTS_AS_VARS` and the Ansible fact namespace `ansible_facts.*` have been added in Ansible 2.5. In the [porting guide of that version](https://docs.ansible.com/ansible/latest/porting_guides/porting_guide_2.5.html#ansible-fact-namespacing), it stated that:

> A new configuration variable, `inject_facts_as_vars`, has been added to ansible.cfg. Its default setting, 'True', keeps the 2.4 behavior of facts variables being set in the old `ansible_*` locations (while also writing them to the new namespace). This variable is expected to be set to 'False' in a future release. When `inject_facts_as_vars` is set to False, you must refer to ansible_facts through the new `ansible_facts.*` namespace.