### PR TITLE
Fix Fedora

### DIFF
--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -9,3 +9,4 @@
   shell: |
     dnf config-manager --set-enabled crb
   changed_when: false
+  when: ansible_distribution != 'Fedora'


### PR DESCRIPTION
Fedora doesn't need the CRB repository and trying to enable it fails with this error:

> [ERROR]: Task failed: Module failed: non-zero return code
> Origin: /home/user/.ansible/roles/geerlingguy.certbot/tasks/setup-RedHat.yml:8:3
> 
> 6     state: present
> 7
> 8 - name: Enable DNF module for Rocky/AlmaLinux.
>     ^ column 3
> 
> fatal: [hostname]: FAILED! => {"changed": false, "cmd": "dnf config-manager --set-enabled crb\n", "delta": "0:00:00.317614", "end": "2026-01-24 23:56:36.466725", "msg": "non-zero return code", "rc": 2, "start": "2026-01-24 23:56:36.149111", "stderr": "Unknown argument \"--set-enabled\" for command \"config-manager\". Add \"--help\" for more information about the arguments.", "stderr_lines": ["Unknown argument \"--set-enabled\" for command \"config-manager\". Add \"--help\" for more information about the arguments."], "stdout": "", "stdout_lines": []}

This commit makes it work by skipping the task on Fedora.

Thank you and have a nice day!