### PR TITLE
Update to support how certbot 5.5 displays domains

### DIFF
--- a/tasks/create-cert-standalone.yml
+++ b/tasks/create-cert-standalone.yml
@@ -44,7 +44,7 @@
 - name: Check if domains have changed
   block:
     - name: Register certificate domains
-      shell: "{{ certbot_script }} certificates --cert-name {{ cert_item_name }} | grep Domains | cut -d':' -f2"
+      shell: "{{ certbot_script }} certificates --cert-name {{ cert_item_name }} | grep -E '(Domains|Identifiers)' | cut -d':' -f2"
       changed_when: false
       register: letsencrypt_cert_domains_dirty
 

--- a/tasks/create-cert-webroot.yml
+++ b/tasks/create-cert-webroot.yml
@@ -16,7 +16,7 @@
 - name: Check if domains have changed
   block:
     - name: Register certificate domains
-      shell: "{{ certbot_script }} certificates --cert-name {{ cert_item_name }} | grep Domains | cut -d':' -f2"
+      shell: "{{ certbot_script }} certificates --cert-name {{ cert_item_name }} | grep -E '(Domains|Identifiers)' | cut -d':' -f2"
       changed_when: false
       register: letsencrypt_cert_domains_dirty
 


### PR DESCRIPTION
As a part of Certbot 5+, the way domain names are returned from `certbot certificates` has [changed]( https://github.com/certbot/certbot/pull/10468) 

The domains are now specified under the keyword `Identifiers`

This PR updates the grep to use regex to identify both new and old format.




Specific change/line: https://github.com/jsha/certbot/blame/8914ff985e362bad39c2fa131b00a47699066c0c/certbot/src/certbot/_internal/cert_manager.py#L287C6-L287C6