### PR TITLE
Fix "domains changed" check for certbot 5.x (Identifiers field)

### DIFF
--- a/tasks/create-cert-standalone.yml
+++ b/tasks/create-cert-standalone.yml
@@ -44,7 +44,7 @@
 - name: Check if domains have changed
   block:
     - name: Register certificate domains
-      shell: "{{ certbot_script }} certificates --cert-name {{ cert_item_name }} | grep Domains | cut -d':' -f2"
+      shell: "{{ certbot_script }} certificates --cert-name {{ cert_item_name }} | grep -E 'Domains|Identifiers' | cut -d':' -f2"
       changed_when: false
       register: letsencrypt_cert_domains_dirty
 

--- a/tasks/create-cert-webroot.yml
+++ b/tasks/create-cert-webroot.yml
@@ -16,7 +16,7 @@
 - name: Check if domains have changed
   block:
     - name: Register certificate domains
-      shell: "{{ certbot_script }} certificates --cert-name {{ cert_item_name }} | grep Domains | cut -d':' -f2"
+      shell: "{{ certbot_script }} certificates --cert-name {{ cert_item_name }} | grep -E 'Domains|Identifiers' | cut -d':' -f2"
       changed_when: false
       register: letsencrypt_cert_domains_dirty
 


### PR DESCRIPTION
## Problem

certbot 5.x renamed the field in `certbot certificates` output from
`Domains:` to `Identifiers:`.

The "Check if domains have changed" block greps that output for `Domains`
to read a certificate's current domains. On certbot 5.x the grep matches
nothing, so `letsencrypt_cert_domains` is empty, `letsencrypt_cert_domains_changed`
is always `true`, and the "Generate new certificate" task runs on every
play — reissuing every certificate on each run. With certbot's
non-interactive `certonly` that is a genuine reissue, which quickly hits
the Let's Encrypt duplicate-certificate rate limit.

## Change

Match both the old `Domains` and the new `Identifiers` label in
`create-cert-standalone.yml` and `create-cert-webroot.yml`, so the check
works on certbot 4.x and 5.x alike.

## Testing

Reproduced on Debian 12 with certbot 5.6.0: before this change every
certificate was reissued on every run; afterwards, unchanged certificates
are correctly detected and skipped.

## Note

Happy to add a test covering the certbot 5.x `certbot certificates` output
format if you would like one — let me know what shape you would prefer
(the molecule scenario does not currently exercise the domain-change path).