### PR TITLE
Remove CI conflict markers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,16 +50,6 @@ jobs:
           - distro: debian12
             playbook: converge.yml
             experimental: false
-<<<<<<< Updated upstream
-=======
-          - distro: debian10
-            playbook: converge.yml
-            experimental: false
-          # Source install started failing recently.
-          # - distro: centos7
-          #   playbook: playbook-source-install.yml
-          #   experimental: false
->>>>>>> Stashed changes
 
           - distro: rockylinux9
             playbook: playbook-snap-install.yml


### PR DESCRIPTION
## Summary

Removes leftover Git conflict markers from the GitHub Actions CI workflow matrix.

## Details

The current workflow file contains unresolved conflict marker lines around the Molecule matrix. Those markers make the workflow YAML invalid for GitHub Actions.

This change keeps the current active matrix entries and only removes the conflict-marker block.

## Validation

- Parsed `.github/workflows/ci.yml` with PyYAML successfully.
- Confirmed no `<<<<<<<`, `=======`, or `>>>>>>>` markers remain in the workflow file.
