### PR TITLE
Fix #247: Ensure a compatible cron is installed before adding the renewal cron job

### DIFF
--- a/.ansible/roles/geerlingguy.certbot
+++ b/.ansible/roles/geerlingguy.certbot
@@ -1,0 +1,1 @@
+/home/arun/Claude/oss/ansible-role-certbot

--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ If you want to fully automate the process of adding a new certificate, but don't
 
 By default, this role adds a cron job that will renew all installed certificates once per day at the hour and minute of your choosing.
 
+The role ensures a vixie-cron-compatible cron daemon is installed (`cron` on Debian-based systems, `cronie` on RedHat-based systems, overridable via `certbot_cron_package`), since Ansible's `cron` module cannot manage crontabs through `systemd-cron`.
+
 You can test the auto-renewal (without actually renewing the cert) with the command:
 
     /opt/certbot/certbot-auto renew --dry-run

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,7 @@ certbot_auto_renew_user: "{{ ansible_user | default(lookup('env', 'USER')) }}"
 certbot_auto_renew_hour: "3"
 certbot_auto_renew_minute: "30"
 certbot_auto_renew_options: "--quiet"
+certbot_cron_package: "{{ 'cronie' if ansible_facts.os_family == 'RedHat' else 'cron' }}"
 
 certbot_testmode: false
 certbot_hsts: false

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -14,15 +14,9 @@
 
     - name: Install dependencies (RedHat).
       yum:
-        name:
-          - cronie
-          - epel-release
+        name: epel-release
         state: present
       when: ansible_facts.os_family == 'RedHat'
-
-    - name: Install cron (Debian).
-      apt: name=cron state=present
-      when: ansible_facts.os_family == 'Debian'
 
   roles:
     - geerlingguy.certbot

--- a/tasks/renew-cron.yml
+++ b/tasks/renew-cron.yml
@@ -1,4 +1,13 @@
 ---
+# The cron module requires a vixie-cron-compatible crontab. Minimal systems may
+# have no cron at all, and systemd-cron's crontab exits 2 (instead of 1) for a
+# user with no crontab yet, which the cron module reports as "Unable to read
+# crontab". See: https://github.com/geerlingguy/ansible-role-certbot/issues/247
+- name: Ensure cron is installed (if configured).
+  package:
+    name: "{{ certbot_cron_package }}"
+    state: present
+
 - name: Add cron job for certbot renewal (if configured).
   cron:
     name: Certbot automatic renewal.


### PR DESCRIPTION
Fixes #247 — root cause analysis in [this comment](https://github.com/geerlingguy/ansible-role-certbot/issues/247#issuecomment-5270735539): minimal Ubuntu 24.04 systems may have no cron at all, or ship `systemd-cron`, whose `crontab` exits 2 (instead of 1) for a user with no crontab yet — the `cron` module reports that as `Unable to read crontab`. Ansible core closed ansible/ansible#84680 as out of scope, so the role is the right place to guarantee a compatible cron.

## Changes

- New task in `tasks/renew-cron.yml` ensuring a vixie-cron-compatible package is installed before the cron job is managed (runs under the existing `certbot_auto_renew` guard).
- New default `certbot_cron_package`: `cron` on Debian-family, `cronie` on RedHat-family, overridable.
- Removed the equivalent pre-install workaround from `molecule/default/converge.yml` — the test harness was already compensating for exactly this gap, and removing it makes CI exercise the new role task.
- README note in the auto-renewal section.

## Verification

- `MOLECULE_DISTRO=ubuntu2404 molecule test` passes locally end-to-end, including idempotence, with the harness workaround removed.
- On a systemd-cron system, `apt-get install cron` swaps the packages cleanly (verified on `ubuntu:24.04`), after which `crontab -l` returns the module-compatible rc=1.